### PR TITLE
fix: Invalidate cloudfront cache after rewriting static files

### DIFF
--- a/assets/lambda/S3EnvRewriter.ts
+++ b/assets/lambda/S3EnvRewriter.ts
@@ -111,7 +111,7 @@ const doRewrites = async (event: CdkCustomResourceEvent) => {
     const cloudfront = new AWS.CloudFront();
     const invalidationRes = await cloudfront
       .createInvalidation({
-        DistributionId: process.env.CLOUDFRONT_DISTRIBUTION_ID!,
+        DistributionId: cloudfrontDistributionId,
         InvalidationBatch: {
           CallerReference: Date.now().toString(),
           Paths: {

--- a/src/NextjsAssetsDeployment.ts
+++ b/src/NextjsAssetsDeployment.ts
@@ -74,6 +74,7 @@ export class NextJsAssetsDeployment extends Construct {
           env: getS3ReplaceValues(this.props.environment, true),
         },
         debug: true,
+        cloudfrontDistributionId: this.props.distribution?.distributionId,
       });
       // wait for s3 assets to be uploaded first before running
       rewriter.node.addDependency(...this.deployments);

--- a/src/NextjsS3EnvRewriter.ts
+++ b/src/NextjsS3EnvRewriter.ts
@@ -22,6 +22,7 @@ export interface RewriterParams {
   readonly s3keys: string[]; // files to rewrite
   readonly replacementConfig: RewriteReplacementsConfig;
   readonly debug?: boolean;
+  readonly cloudfrontDistributionId?: string;
 }
 
 export interface NextjsS3EnvRewriterProps extends NextjsBaseProps, RewriterParams {
@@ -38,7 +39,7 @@ export class NextjsS3EnvRewriter extends Construct {
   constructor(scope: Construct, id: string, props: NextjsS3EnvRewriterProps) {
     super(scope, id);
 
-    const { s3Bucket, s3keys, replacementConfig, nextBuild, debug } = props;
+    const { s3Bucket, s3keys, replacementConfig, nextBuild, debug, cloudfrontDistributionId } = props;
 
     if (s3keys.length === 0) return;
 
@@ -101,6 +102,7 @@ export class NextjsS3EnvRewriter extends Construct {
         jsonS3Bucket: replacementConfig.jsonS3Bucket?.bucketName,
       },
       debug,
+      cloudfrontDistributionId,
     };
     new CustomResource(this, 'RewriteStatic', {
       serviceToken: provider.serviceToken,


### PR DESCRIPTION
Unfortunate but if someone requests static files during a deployment the unrewritten versions can get stuck in CF.
Not sure how to prevent this from happening in the first place though :( 