### PR TITLE
fix: fix precendence ordering of image path

### DIFF
--- a/src/Nextjs.ts
+++ b/src/Nextjs.ts
@@ -495,12 +495,6 @@ export class Nextjs extends Construct {
         // known dynamic routes
         'api/*': lambdaBehavior,
         '_next/data/*': lambdaBehavior,
-
-        // known static routes
-        // it would be nice to create routes for all the static files we know of
-        // but we run into the limit of CacheBehaviors per distribution
-        '_next/*': staticBehavior,
-
         // dynamic images go to lambda
         '_next/image*': {
           viewerProtocolPolicy,
@@ -511,6 +505,11 @@ export class Nextjs extends Construct {
           cachePolicy: imageCachePolicy,
           originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER, // not sure what goes here
         },
+
+        // known static routes
+        // it would be nice to create routes for all the static files we know of
+        // but we run into the limit of CacheBehaviors per distribution
+        '_next/*': staticBehavior,
 
         ...(cfDistributionProps?.additionalBehaviors || {}),
       },


### PR DESCRIPTION
If you look at the CloudFront Distribution, the precedence ordering of `_next/*` is above `_next/image*`.  I believe that means it'll never match `_next/image`. Please correct me if I'm wrong.

