### PR TITLE
feat: image optimization

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.50.0",
+      "version": "2.53.0",
       "type": "build"
     },
     {
@@ -87,10 +87,6 @@
     },
     {
       "name": "json-schema",
-      "type": "build"
-    },
-    {
-      "name": "next",
       "type": "build"
     },
     {
@@ -188,7 +184,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.50.0",
+      "version": "^2.53.0",
       "type": "peer"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -117,6 +117,10 @@
       "type": "build"
     },
     {
+      "name": "@aws-sdk/client-s3",
+      "type": "bundled"
+    },
+    {
       "name": "@types/aws-lambda",
       "type": "bundled"
     },
@@ -162,6 +166,10 @@
     },
     {
       "name": "micromatch",
+      "type": "bundled"
+    },
+    {
+      "name": "next",
       "type": "bundled"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -90,6 +90,10 @@
       "type": "build"
     },
     {
+      "name": "next",
+      "type": "build"
+    },
+    {
       "name": "npm-check-updates",
       "version": "^16",
       "type": "build"
@@ -166,10 +170,6 @@
     },
     {
       "name": "micromatch",
-      "type": "bundled"
-    },
-    {
-      "name": "next",
       "type": "bundled"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -25,7 +25,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'fs-extra',
     'indent-string',
     'micromatch',
-    'next',
     '@aws-sdk/client-s3',
     '@types/cross-spawn',
     '@types/fs-extra',
@@ -37,7 +36,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'jszip',
     'glob',
   ] /* Runtime dependencies of this module. */,
-  devDeps: ['aws-sdk', 'constructs@10.1.21'] /* Build dependencies for this module. */,
+  devDeps: ['aws-sdk', 'constructs@10.1.21', 'next'] /* Build dependencies for this module. */,
 
   // do not generate sample test files
   sampleCode: false,

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,4 +1,4 @@
-const { awscdk, build } = require('projen');
+const { awscdk } = require('projen');
 const project = new awscdk.AwsCdkConstructLibrary({
   author: 'JetBridge',
   authorAddress: 'mischa@jetbridge.com',

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -25,6 +25,8 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'fs-extra',
     'indent-string',
     'micromatch',
+    'next',
+    '@aws-sdk/client-s3',
     '@types/cross-spawn',
     '@types/fs-extra',
     '@types/micromatch',

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,8 +1,8 @@
-const { awscdk } = require('projen');
+const { awscdk, build } = require('projen');
 const project = new awscdk.AwsCdkConstructLibrary({
   author: 'JetBridge',
   authorAddress: 'mischa@jetbridge.com',
-  cdkVersion: '2.50.0',
+  cdkVersion: '2.53.0',
   defaultReleaseBranch: 'main',
   name: 'cdk-nextjs-standalone',
   repositoryUrl: 'https://github.com/jetbridge/cdk-nextjs.git',
@@ -36,7 +36,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'jszip',
     'glob',
   ] /* Runtime dependencies of this module. */,
-  devDeps: ['aws-sdk', 'constructs@10.1.21', 'next'] /* Build dependencies for this module. */,
+  devDeps: ['aws-sdk', 'constructs@10.1.21'] /* Build dependencies for this module. */,
 
   // do not generate sample test files
   sampleCode: false,

--- a/API.md
+++ b/API.md
@@ -45,6 +45,24 @@ new ImageOptimizationLambda(scope: Construct, id: string, props: ImageOptimizati
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.addEventSource">addEventSource</a></code> | Adds an event source to this function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.addEventSourceMapping">addEventSourceMapping</a></code> | Adds an event source that maps to this AWS Lambda function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.addFunctionUrl">addFunctionUrl</a></code> | Adds a url to this lambda function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.addPermission">addPermission</a></code> | Adds a permission to the Lambda resource policy. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.addToRolePolicy">addToRolePolicy</a></code> | Adds a statement to the IAM role assumed by the instance. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.configureAsyncInvoke">configureAsyncInvoke</a></code> | Configures options for asynchronous invocation. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.considerWarningOnInvokeFunctionPermissions">considerWarningOnInvokeFunctionPermissions</a></code> | A warning will be added to functions under the following conditions: - permissions that include `lambda:InvokeFunction` are added to the unqualified function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.grantInvoke">grantInvoke</a></code> | Grant the given identity permissions to invoke this Lambda. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.grantInvokeUrl">grantInvokeUrl</a></code> | Grant the given identity permissions to invoke this Lambda Function URL. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metric">metric</a></code> | Return the given named metric for this Function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricDuration">metricDuration</a></code> | How long execution of this Lambda takes. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricErrors">metricErrors</a></code> | How many invocations of this Lambda fail. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricInvocations">metricInvocations</a></code> | How often this Lambda is invoked. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricThrottles">metricThrottles</a></code> | How often this Lambda is throttled. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.addAlias">addAlias</a></code> | Defines an alias for this function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.addEnvironment">addEnvironment</a></code> | Adds an environment variable to this Lambda function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.addLayers">addLayers</a></code> | Adds one or more Lambda Layers to this Lambda function. |
 
 ---
 
@@ -56,11 +74,383 @@ public toString(): string
 
 Returns a string representation of this construct.
 
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="cdk-nextjs-standalone.ImageOptimizationLambda.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy: RemovalPolicy): void
+```
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
+
+###### `policy`<sup>Required</sup> <a name="policy" id="cdk-nextjs-standalone.ImageOptimizationLambda.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+##### `addEventSource` <a name="addEventSource" id="cdk-nextjs-standalone.ImageOptimizationLambda.addEventSource"></a>
+
+```typescript
+public addEventSource(source: IEventSource): void
+```
+
+Adds an event source to this function.
+
+Event sources are implemented in the @aws-cdk/aws-lambda-event-sources module.
+
+The following example adds an SQS Queue as an event source:
+```
+import { SqsEventSource } from '@aws-cdk/aws-lambda-event-sources';
+myFunction.addEventSource(new SqsEventSource(myQueue));
+```
+
+###### `source`<sup>Required</sup> <a name="source" id="cdk-nextjs-standalone.ImageOptimizationLambda.addEventSource.parameter.source"></a>
+
+- *Type:* aws-cdk-lib.aws_lambda.IEventSource
+
+---
+
+##### `addEventSourceMapping` <a name="addEventSourceMapping" id="cdk-nextjs-standalone.ImageOptimizationLambda.addEventSourceMapping"></a>
+
+```typescript
+public addEventSourceMapping(id: string, options: EventSourceMappingOptions): EventSourceMapping
+```
+
+Adds an event source that maps to this AWS Lambda function.
+
+###### `id`<sup>Required</sup> <a name="id" id="cdk-nextjs-standalone.ImageOptimizationLambda.addEventSourceMapping.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `options`<sup>Required</sup> <a name="options" id="cdk-nextjs-standalone.ImageOptimizationLambda.addEventSourceMapping.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.aws_lambda.EventSourceMappingOptions
+
+---
+
+##### `addFunctionUrl` <a name="addFunctionUrl" id="cdk-nextjs-standalone.ImageOptimizationLambda.addFunctionUrl"></a>
+
+```typescript
+public addFunctionUrl(options?: FunctionUrlOptions): FunctionUrl
+```
+
+Adds a url to this lambda function.
+
+###### `options`<sup>Optional</sup> <a name="options" id="cdk-nextjs-standalone.ImageOptimizationLambda.addFunctionUrl.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.aws_lambda.FunctionUrlOptions
+
+---
+
+##### `addPermission` <a name="addPermission" id="cdk-nextjs-standalone.ImageOptimizationLambda.addPermission"></a>
+
+```typescript
+public addPermission(id: string, permission: Permission): void
+```
+
+Adds a permission to the Lambda resource policy.
+
+> [Permission for details.](Permission for details.)
+
+###### `id`<sup>Required</sup> <a name="id" id="cdk-nextjs-standalone.ImageOptimizationLambda.addPermission.parameter.id"></a>
+
+- *Type:* string
+
+The id for the permission construct.
+
+---
+
+###### `permission`<sup>Required</sup> <a name="permission" id="cdk-nextjs-standalone.ImageOptimizationLambda.addPermission.parameter.permission"></a>
+
+- *Type:* aws-cdk-lib.aws_lambda.Permission
+
+The permission to grant to this Lambda function.
+
+---
+
+##### `addToRolePolicy` <a name="addToRolePolicy" id="cdk-nextjs-standalone.ImageOptimizationLambda.addToRolePolicy"></a>
+
+```typescript
+public addToRolePolicy(statement: PolicyStatement): void
+```
+
+Adds a statement to the IAM role assumed by the instance.
+
+###### `statement`<sup>Required</sup> <a name="statement" id="cdk-nextjs-standalone.ImageOptimizationLambda.addToRolePolicy.parameter.statement"></a>
+
+- *Type:* aws-cdk-lib.aws_iam.PolicyStatement
+
+---
+
+##### `configureAsyncInvoke` <a name="configureAsyncInvoke" id="cdk-nextjs-standalone.ImageOptimizationLambda.configureAsyncInvoke"></a>
+
+```typescript
+public configureAsyncInvoke(options: EventInvokeConfigOptions): void
+```
+
+Configures options for asynchronous invocation.
+
+###### `options`<sup>Required</sup> <a name="options" id="cdk-nextjs-standalone.ImageOptimizationLambda.configureAsyncInvoke.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.aws_lambda.EventInvokeConfigOptions
+
+---
+
+##### `considerWarningOnInvokeFunctionPermissions` <a name="considerWarningOnInvokeFunctionPermissions" id="cdk-nextjs-standalone.ImageOptimizationLambda.considerWarningOnInvokeFunctionPermissions"></a>
+
+```typescript
+public considerWarningOnInvokeFunctionPermissions(scope: Construct, action: string): void
+```
+
+A warning will be added to functions under the following conditions: - permissions that include `lambda:InvokeFunction` are added to the unqualified function.
+
+function.currentVersion is invoked before or after the permission is created.
+
+This applies only to permissions on Lambda functions, not versions or aliases.
+This function is overridden as a noOp for QualifiedFunctionBase.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="cdk-nextjs-standalone.ImageOptimizationLambda.considerWarningOnInvokeFunctionPermissions.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### `action`<sup>Required</sup> <a name="action" id="cdk-nextjs-standalone.ImageOptimizationLambda.considerWarningOnInvokeFunctionPermissions.parameter.action"></a>
+
+- *Type:* string
+
+---
+
+##### `grantInvoke` <a name="grantInvoke" id="cdk-nextjs-standalone.ImageOptimizationLambda.grantInvoke"></a>
+
+```typescript
+public grantInvoke(grantee: IGrantable): Grant
+```
+
+Grant the given identity permissions to invoke this Lambda.
+
+###### `grantee`<sup>Required</sup> <a name="grantee" id="cdk-nextjs-standalone.ImageOptimizationLambda.grantInvoke.parameter.grantee"></a>
+
+- *Type:* aws-cdk-lib.aws_iam.IGrantable
+
+---
+
+##### `grantInvokeUrl` <a name="grantInvokeUrl" id="cdk-nextjs-standalone.ImageOptimizationLambda.grantInvokeUrl"></a>
+
+```typescript
+public grantInvokeUrl(grantee: IGrantable): Grant
+```
+
+Grant the given identity permissions to invoke this Lambda Function URL.
+
+###### `grantee`<sup>Required</sup> <a name="grantee" id="cdk-nextjs-standalone.ImageOptimizationLambda.grantInvokeUrl.parameter.grantee"></a>
+
+- *Type:* aws-cdk-lib.aws_iam.IGrantable
+
+---
+
+##### `metric` <a name="metric" id="cdk-nextjs-standalone.ImageOptimizationLambda.metric"></a>
+
+```typescript
+public metric(metricName: string, props?: MetricOptions): Metric
+```
+
+Return the given named metric for this Function.
+
+###### `metricName`<sup>Required</sup> <a name="metricName" id="cdk-nextjs-standalone.ImageOptimizationLambda.metric.parameter.metricName"></a>
+
+- *Type:* string
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metric.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricDuration` <a name="metricDuration" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricDuration"></a>
+
+```typescript
+public metricDuration(props?: MetricOptions): Metric
+```
+
+How long execution of this Lambda takes.
+
+Average over 5 minutes
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricDuration.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricErrors` <a name="metricErrors" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricErrors"></a>
+
+```typescript
+public metricErrors(props?: MetricOptions): Metric
+```
+
+How many invocations of this Lambda fail.
+
+Sum over 5 minutes
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricErrors.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricInvocations` <a name="metricInvocations" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricInvocations"></a>
+
+```typescript
+public metricInvocations(props?: MetricOptions): Metric
+```
+
+How often this Lambda is invoked.
+
+Sum over 5 minutes
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricInvocations.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricThrottles` <a name="metricThrottles" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricThrottles"></a>
+
+```typescript
+public metricThrottles(props?: MetricOptions): Metric
+```
+
+How often this Lambda is throttled.
+
+Sum over 5 minutes
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricThrottles.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `addAlias` <a name="addAlias" id="cdk-nextjs-standalone.ImageOptimizationLambda.addAlias"></a>
+
+```typescript
+public addAlias(aliasName: string, options?: AliasOptions): Alias
+```
+
+Defines an alias for this function.
+
+The alias will automatically be updated to point to the latest version of
+the function as it is being updated during a deployment.
+
+```ts
+declare const fn: lambda.Function;
+
+fn.addAlias('Live');
+
+// Is equivalent to
+
+new lambda.Alias(this, 'AliasLive', {
+   aliasName: 'Live',
+   version: fn.currentVersion,
+});
+```
+
+###### `aliasName`<sup>Required</sup> <a name="aliasName" id="cdk-nextjs-standalone.ImageOptimizationLambda.addAlias.parameter.aliasName"></a>
+
+- *Type:* string
+
+The name of the alias.
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="cdk-nextjs-standalone.ImageOptimizationLambda.addAlias.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.aws_lambda.AliasOptions
+
+Alias options.
+
+---
+
+##### `addEnvironment` <a name="addEnvironment" id="cdk-nextjs-standalone.ImageOptimizationLambda.addEnvironment"></a>
+
+```typescript
+public addEnvironment(key: string, value: string, options?: EnvironmentOptions): Function
+```
+
+Adds an environment variable to this Lambda function.
+
+If this is a ref to a Lambda function, this operation results in a no-op.
+
+###### `key`<sup>Required</sup> <a name="key" id="cdk-nextjs-standalone.ImageOptimizationLambda.addEnvironment.parameter.key"></a>
+
+- *Type:* string
+
+The environment variable key.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="cdk-nextjs-standalone.ImageOptimizationLambda.addEnvironment.parameter.value"></a>
+
+- *Type:* string
+
+The environment variable's value.
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="cdk-nextjs-standalone.ImageOptimizationLambda.addEnvironment.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.aws_lambda.EnvironmentOptions
+
+Environment variable options.
+
+---
+
+##### `addLayers` <a name="addLayers" id="cdk-nextjs-standalone.ImageOptimizationLambda.addLayers"></a>
+
+```typescript
+public addLayers(layers: ILayerVersion): void
+```
+
+Adds one or more Lambda Layers to this Lambda function.
+
+###### `layers`<sup>Required</sup> <a name="layers" id="cdk-nextjs-standalone.ImageOptimizationLambda.addLayers.parameter.layers"></a>
+
+- *Type:* aws-cdk-lib.aws_lambda.ILayerVersion
+
+the layers to be added.
+
+---
+
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.classifyVersionProperty">classifyVersionProperty</a></code> | Record whether specific properties in the `AWS::Lambda::Function` resource should also be associated to the Version resource. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionArn">fromFunctionArn</a></code> | Import a lambda function into the CDK using its ARN. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionAttributes">fromFunctionAttributes</a></code> | Creates a Lambda function object which represents a function not defined within this stack. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionName">fromFunctionName</a></code> | Import a lambda function into the CDK using its name. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricAll">metricAll</a></code> | Return the given named metric for this Lambda. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricAllConcurrentExecutions">metricAllConcurrentExecutions</a></code> | Metric for the number of concurrent executions across all Lambdas. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricAllDuration">metricAllDuration</a></code> | Metric for the Duration executing all Lambdas. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricAllErrors">metricAllErrors</a></code> | Metric for the number of Errors executing all Lambdas. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricAllInvocations">metricAllInvocations</a></code> | Metric for the number of invocations of all Lambdas. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricAllThrottles">metricAllThrottles</a></code> | Metric for the number of throttled invocations of all Lambdas. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.metricAllUnreservedConcurrentExecutions">metricAllUnreservedConcurrentExecutions</a></code> | Metric for the number of unreserved concurrent executions across all Lambdas. |
 
 ---
 
@@ -82,13 +472,298 @@ Any object.
 
 ---
 
+##### `isOwnedResource` <a name="isOwnedResource" id="cdk-nextjs-standalone.ImageOptimizationLambda.isOwnedResource"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.isOwnedResource(construct: IConstruct)
+```
+
+Returns true if the construct was created by CDK, and false otherwise.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="cdk-nextjs-standalone.ImageOptimizationLambda.isOwnedResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `isResource` <a name="isResource" id="cdk-nextjs-standalone.ImageOptimizationLambda.isResource"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.isResource(construct: IConstruct)
+```
+
+Check whether the given construct is a Resource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="cdk-nextjs-standalone.ImageOptimizationLambda.isResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `classifyVersionProperty` <a name="classifyVersionProperty" id="cdk-nextjs-standalone.ImageOptimizationLambda.classifyVersionProperty"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.classifyVersionProperty(propertyName: string, locked: boolean)
+```
+
+Record whether specific properties in the `AWS::Lambda::Function` resource should also be associated to the Version resource.
+
+See 'currentVersion' section in the module README for more details.
+
+###### `propertyName`<sup>Required</sup> <a name="propertyName" id="cdk-nextjs-standalone.ImageOptimizationLambda.classifyVersionProperty.parameter.propertyName"></a>
+
+- *Type:* string
+
+The property to classify.
+
+---
+
+###### `locked`<sup>Required</sup> <a name="locked" id="cdk-nextjs-standalone.ImageOptimizationLambda.classifyVersionProperty.parameter.locked"></a>
+
+- *Type:* boolean
+
+whether the property should be associated to the version or not.
+
+---
+
+##### `fromFunctionArn` <a name="fromFunctionArn" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionArn"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.fromFunctionArn(scope: Construct, id: string, functionArn: string)
+```
+
+Import a lambda function into the CDK using its ARN.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionArn.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `functionArn`<sup>Required</sup> <a name="functionArn" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionArn.parameter.functionArn"></a>
+
+- *Type:* string
+
+---
+
+##### `fromFunctionAttributes` <a name="fromFunctionAttributes" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionAttributes"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.fromFunctionAttributes(scope: Construct, id: string, attrs: FunctionAttributes)
+```
+
+Creates a Lambda function object which represents a function not defined within this stack.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionAttributes.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent construct.
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionAttributes.parameter.id"></a>
+
+- *Type:* string
+
+The name of the lambda construct.
+
+---
+
+###### `attrs`<sup>Required</sup> <a name="attrs" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionAttributes.parameter.attrs"></a>
+
+- *Type:* aws-cdk-lib.aws_lambda.FunctionAttributes
+
+the attributes of the function to import.
+
+---
+
+##### `fromFunctionName` <a name="fromFunctionName" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionName"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.fromFunctionName(scope: Construct, id: string, functionName: string)
+```
+
+Import a lambda function into the CDK using its name.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionName.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `functionName`<sup>Required</sup> <a name="functionName" id="cdk-nextjs-standalone.ImageOptimizationLambda.fromFunctionName.parameter.functionName"></a>
+
+- *Type:* string
+
+---
+
+##### `metricAll` <a name="metricAll" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAll"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.metricAll(metricName: string, props?: MetricOptions)
+```
+
+Return the given named metric for this Lambda.
+
+###### `metricName`<sup>Required</sup> <a name="metricName" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAll.parameter.metricName"></a>
+
+- *Type:* string
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAll.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricAllConcurrentExecutions` <a name="metricAllConcurrentExecutions" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllConcurrentExecutions"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.metricAllConcurrentExecutions(props?: MetricOptions)
+```
+
+Metric for the number of concurrent executions across all Lambdas.
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllConcurrentExecutions.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricAllDuration` <a name="metricAllDuration" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllDuration"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.metricAllDuration(props?: MetricOptions)
+```
+
+Metric for the Duration executing all Lambdas.
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllDuration.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricAllErrors` <a name="metricAllErrors" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllErrors"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.metricAllErrors(props?: MetricOptions)
+```
+
+Metric for the number of Errors executing all Lambdas.
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllErrors.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricAllInvocations` <a name="metricAllInvocations" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllInvocations"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.metricAllInvocations(props?: MetricOptions)
+```
+
+Metric for the number of invocations of all Lambdas.
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllInvocations.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricAllThrottles` <a name="metricAllThrottles" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllThrottles"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.metricAllThrottles(props?: MetricOptions)
+```
+
+Metric for the number of throttled invocations of all Lambdas.
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllThrottles.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricAllUnreservedConcurrentExecutions` <a name="metricAllUnreservedConcurrentExecutions" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllUnreservedConcurrentExecutions"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.metricAllUnreservedConcurrentExecutions(props?: MetricOptions)
+```
+
+Metric for the number of unreserved concurrent executions across all Lambdas.
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.metricAllUnreservedConcurrentExecutions.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
 #### Properties <a name="Properties" id="Properties"></a>
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.architecture">architecture</a></code> | <code>aws-cdk-lib.aws_lambda.Architecture</code> | The architecture of this Lambda Function (this is an optional attribute and defaults to X86_64). |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.connections">connections</a></code> | <code>aws-cdk-lib.aws_ec2.Connections</code> | Access the Connections object. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.functionArn">functionArn</a></code> | <code>string</code> | ARN of this function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.functionName">functionName</a></code> | <code>string</code> | Name of this function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.grantPrincipal">grantPrincipal</a></code> | <code>aws-cdk-lib.aws_iam.IPrincipal</code> | The principal this Lambda Function is running as. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.isBoundToVpc">isBoundToVpc</a></code> | <code>boolean</code> | Whether or not this Lambda function was bound to a VPC. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.latestVersion">latestVersion</a></code> | <code>aws-cdk-lib.aws_lambda.IVersion</code> | The `$LATEST` version of this function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.permissionsNode">permissionsNode</a></code> | <code>constructs.Node</code> | The construct node where permissions are attached. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.resourceArnsForGrantInvoke">resourceArnsForGrantInvoke</a></code> | <code>string[]</code> | The ARN(s) to put into the resource field of the generated IAM policy for grantInvoke(). |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.role">role</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | Execution role associated with this function. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.currentVersion">currentVersion</a></code> | <code>aws-cdk-lib.aws_lambda.Version</code> | Returns a `lambda.Version` which represents the current version of this Lambda function. A new version will be created every time the function's configuration changes. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.logGroup">logGroup</a></code> | <code>aws-cdk-lib.aws_logs.ILogGroup</code> | The LogGroup where the Lambda function's logs are made available. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.runtime">runtime</a></code> | <code>aws-cdk-lib.aws_lambda.Runtime</code> | The runtime configured for this lambda. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.deadLetterQueue">deadLetterQueue</a></code> | <code>aws-cdk-lib.aws_sqs.IQueue</code> | The DLQ (as queue) associated with this Lambda Function (this is an optional attribute). |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.deadLetterTopic">deadLetterTopic</a></code> | <code>aws-cdk-lib.aws_sns.ITopic</code> | The DLQ (as topic) associated with this Lambda Function (this is an optional attribute). |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | The timeout configured for this lambda. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | *No description.* |
-| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.lambdaFunction">lambdaFunction</a></code> | <code>aws-cdk-lib.aws_lambda.Function</code> | *No description.* |
 
 ---
 
@@ -104,6 +779,250 @@ The tree node.
 
 ---
 
+##### `env`<sup>Required</sup> <a name="env" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.env"></a>
+
+```typescript
+public readonly env: ResourceEnvironment;
+```
+
+- *Type:* aws-cdk-lib.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### `architecture`<sup>Required</sup> <a name="architecture" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.architecture"></a>
+
+```typescript
+public readonly architecture: Architecture;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.Architecture
+
+The architecture of this Lambda Function (this is an optional attribute and defaults to X86_64).
+
+---
+
+##### `connections`<sup>Required</sup> <a name="connections" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.connections"></a>
+
+```typescript
+public readonly connections: Connections;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.Connections
+
+Access the Connections object.
+
+Will fail if not a VPC-enabled Lambda Function
+
+---
+
+##### `functionArn`<sup>Required</sup> <a name="functionArn" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.functionArn"></a>
+
+```typescript
+public readonly functionArn: string;
+```
+
+- *Type:* string
+
+ARN of this function.
+
+---
+
+##### `functionName`<sup>Required</sup> <a name="functionName" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.functionName"></a>
+
+```typescript
+public readonly functionName: string;
+```
+
+- *Type:* string
+
+Name of this function.
+
+---
+
+##### `grantPrincipal`<sup>Required</sup> <a name="grantPrincipal" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.grantPrincipal"></a>
+
+```typescript
+public readonly grantPrincipal: IPrincipal;
+```
+
+- *Type:* aws-cdk-lib.aws_iam.IPrincipal
+
+The principal this Lambda Function is running as.
+
+---
+
+##### `isBoundToVpc`<sup>Required</sup> <a name="isBoundToVpc" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.isBoundToVpc"></a>
+
+```typescript
+public readonly isBoundToVpc: boolean;
+```
+
+- *Type:* boolean
+
+Whether or not this Lambda function was bound to a VPC.
+
+If this is is `false`, trying to access the `connections` object will fail.
+
+---
+
+##### `latestVersion`<sup>Required</sup> <a name="latestVersion" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.latestVersion"></a>
+
+```typescript
+public readonly latestVersion: IVersion;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.IVersion
+
+The `$LATEST` version of this function.
+
+Note that this is reference to a non-specific AWS Lambda version, which
+means the function this version refers to can return different results in
+different invocations.
+
+To obtain a reference to an explicit version which references the current
+function configuration, use `lambdaFunction.currentVersion` instead.
+
+---
+
+##### `permissionsNode`<sup>Required</sup> <a name="permissionsNode" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.permissionsNode"></a>
+
+```typescript
+public readonly permissionsNode: Node;
+```
+
+- *Type:* constructs.Node
+
+The construct node where permissions are attached.
+
+---
+
+##### `resourceArnsForGrantInvoke`<sup>Required</sup> <a name="resourceArnsForGrantInvoke" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.resourceArnsForGrantInvoke"></a>
+
+```typescript
+public readonly resourceArnsForGrantInvoke: string[];
+```
+
+- *Type:* string[]
+
+The ARN(s) to put into the resource field of the generated IAM policy for grantInvoke().
+
+---
+
+##### `role`<sup>Optional</sup> <a name="role" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.role"></a>
+
+```typescript
+public readonly role: IRole;
+```
+
+- *Type:* aws-cdk-lib.aws_iam.IRole
+
+Execution role associated with this function.
+
+---
+
+##### `currentVersion`<sup>Required</sup> <a name="currentVersion" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.currentVersion"></a>
+
+```typescript
+public readonly currentVersion: Version;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.Version
+
+Returns a `lambda.Version` which represents the current version of this Lambda function. A new version will be created every time the function's configuration changes.
+
+You can specify options for this version using the `currentVersionOptions`
+prop when initializing the `lambda.Function`.
+
+---
+
+##### `logGroup`<sup>Required</sup> <a name="logGroup" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.logGroup"></a>
+
+```typescript
+public readonly logGroup: ILogGroup;
+```
+
+- *Type:* aws-cdk-lib.aws_logs.ILogGroup
+
+The LogGroup where the Lambda function's logs are made available.
+
+If either `logRetention` is set or this property is called, a CloudFormation custom resource is added to the stack that
+pre-creates the log group as part of the stack deployment, if it already doesn't exist, and sets the correct log retention
+period (never expire, by default).
+
+Further, if the log group already exists and the `logRetention` is not set, the custom resource will reset the log retention
+to never expire even if it was configured with a different value.
+
+---
+
+##### `runtime`<sup>Required</sup> <a name="runtime" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.runtime"></a>
+
+```typescript
+public readonly runtime: Runtime;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.Runtime
+
+The runtime configured for this lambda.
+
+---
+
+##### `deadLetterQueue`<sup>Optional</sup> <a name="deadLetterQueue" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.deadLetterQueue"></a>
+
+```typescript
+public readonly deadLetterQueue: IQueue;
+```
+
+- *Type:* aws-cdk-lib.aws_sqs.IQueue
+
+The DLQ (as queue) associated with this Lambda Function (this is an optional attribute).
+
+---
+
+##### `deadLetterTopic`<sup>Optional</sup> <a name="deadLetterTopic" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.deadLetterTopic"></a>
+
+```typescript
+public readonly deadLetterTopic: ITopic;
+```
+
+- *Type:* aws-cdk-lib.aws_sns.ITopic
+
+The DLQ (as topic) associated with this Lambda Function (this is an optional attribute).
+
+---
+
+##### `timeout`<sup>Optional</sup> <a name="timeout" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.timeout"></a>
+
+```typescript
+public readonly timeout: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+
+The timeout configured for this lambda.
+
+---
+
 ##### `bucket`<sup>Required</sup> <a name="bucket" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.bucket"></a>
 
 ```typescript
@@ -111,16 +1030,6 @@ public readonly bucket: IBucket;
 ```
 
 - *Type:* aws-cdk-lib.aws_s3.IBucket
-
----
-
-##### `lambdaFunction`<sup>Required</sup> <a name="lambdaFunction" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.lambdaFunction"></a>
-
-```typescript
-public readonly lambdaFunction: Function;
-```
-
-- *Type:* aws-cdk-lib.aws_lambda.Function
 
 ---
 
@@ -610,6 +1519,8 @@ Any object.
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.buildPath">buildPath</a></code> | <code>string</code> | The path to the directory where the server build artifacts are stored. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.imagesManifestPath">imagesManifestPath</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextDir">nextDir</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextPublicDir">nextPublicDir</a></code> | <code>string</code> | Public static files. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneBuildDir">nextStandaloneBuildDir</a></code> | <code>string</code> | NextJS project inside of standalone build. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneDir">nextStandaloneDir</a></code> | <code>string</code> | Entire NextJS build output directory. |
@@ -640,6 +1551,26 @@ public readonly buildPath: string;
 - *Type:* string
 
 The path to the directory where the server build artifacts are stored.
+
+---
+
+##### `imagesManifestPath`<sup>Required</sup> <a name="imagesManifestPath" id="cdk-nextjs-standalone.NextjsBuild.property.imagesManifestPath"></a>
+
+```typescript
+public readonly imagesManifestPath: string;
+```
+
+- *Type:* string
+
+---
+
+##### `nextDir`<sup>Required</sup> <a name="nextDir" id="cdk-nextjs-standalone.NextjsBuild.property.nextDir"></a>
+
+```typescript
+public readonly nextDir: string;
+```
+
+- *Type:* string
 
 ---
 
@@ -1721,7 +2652,8 @@ const imageOptimizationProps: ImageOptimizationProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The internal S3 bucket for application images. |
-| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nextLayer">nextLayer</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsLayer">NextjsLayer</a></code> | NextjsLayer. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | The `NextjsBuild` instance representing the built Nextjs application. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nextLayer">nextLayer</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsLayer">NextjsLayer</a></code> | NextjsLayer - sharp runtime. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.lambdaOptions">lambdaOptions</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
 
 ---
@@ -1829,6 +2761,18 @@ The internal S3 bucket for application images.
 
 ---
 
+##### `nextBuild`<sup>Required</sup> <a name="nextBuild" id="cdk-nextjs-standalone.ImageOptimizationProps.property.nextBuild"></a>
+
+```typescript
+public readonly nextBuild: NextjsBuild;
+```
+
+- *Type:* <a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a>
+
+The `NextjsBuild` instance representing the built Nextjs application.
+
+---
+
 ##### `nextLayer`<sup>Required</sup> <a name="nextLayer" id="cdk-nextjs-standalone.ImageOptimizationProps.property.nextLayer"></a>
 
 ```typescript
@@ -1837,7 +2781,7 @@ public readonly nextLayer: NextjsLayer;
 
 - *Type:* <a href="#cdk-nextjs-standalone.NextjsLayer">NextjsLayer</a>
 
-NextjsLayer.
+NextjsLayer - sharp runtime.
 
 ---
 
@@ -2861,7 +3805,6 @@ const nextjsLambdaProps: NextjsLambdaProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built nextJS application. |
-| <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.nextLayer">nextLayer</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsLayer">NextjsLayer</a></code> | NextjsLayer. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.lambda">lambda</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
 
 ---
@@ -2969,18 +3912,6 @@ Built nextJS application.
 
 ---
 
-##### `nextLayer`<sup>Required</sup> <a name="nextLayer" id="cdk-nextjs-standalone.NextjsLambdaProps.property.nextLayer"></a>
-
-```typescript
-public readonly nextLayer: NextjsLayer;
-```
-
-- *Type:* <a href="#cdk-nextjs-standalone.NextjsLayer">NextjsLayer</a>
-
-NextjsLayer.
-
----
-
 ##### `lambda`<sup>Optional</sup> <a name="lambda" id="cdk-nextjs-standalone.NextjsLambdaProps.property.lambda"></a>
 
 ```typescript
@@ -3025,8 +3956,8 @@ const nextjsProps: NextjsProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
-| <code><a href="#cdk-nextjs-standalone.NextjsProps.property.defaults">defaults</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsDefaultsProps">NextjsDefaultsProps</a></code> | *No description.* |
-| <code><a href="#cdk-nextjs-standalone.NextjsProps.property.imageOptimizationBucket">imageOptimizationBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Allows you to override defaults for the resources created by this construct. |
+| <code><a href="#cdk-nextjs-standalone.NextjsProps.property.defaults">defaults</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsDefaultsProps">NextjsDefaultsProps</a></code> | Allows you to override defaults for the resources created by this construct. |
+| <code><a href="#cdk-nextjs-standalone.NextjsProps.property.imageOptimizationBucket">imageOptimizationBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Optional S3 Bucket to use, defaults to assets bucket. |
 
 ---
 
@@ -3129,6 +4060,8 @@ public readonly defaults: NextjsDefaultsProps;
 
 - *Type:* <a href="#cdk-nextjs-standalone.NextjsDefaultsProps">NextjsDefaultsProps</a>
 
+Allows you to override defaults for the resources created by this construct.
+
 ---
 
 ##### `imageOptimizationBucket`<sup>Optional</sup> <a name="imageOptimizationBucket" id="cdk-nextjs-standalone.NextjsProps.property.imageOptimizationBucket"></a>
@@ -3139,7 +4072,7 @@ public readonly imageOptimizationBucket: IBucket;
 
 - *Type:* aws-cdk-lib.aws_s3.IBucket
 
-Allows you to override defaults for the resources created by this construct.
+Optional S3 Bucket to use, defaults to assets bucket.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -2,6 +2,129 @@
 
 ## Constructs <a name="Constructs" id="Constructs"></a>
 
+### ImageOptimizationLambda <a name="ImageOptimizationLambda" id="cdk-nextjs-standalone.ImageOptimizationLambda"></a>
+
+This lambda handles image optimization.
+
+#### Initializers <a name="Initializers" id="cdk-nextjs-standalone.ImageOptimizationLambda.Initializer"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+new ImageOptimizationLambda(scope: Construct, id: string, props: ImageOptimizationProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.Initializer.parameter.props">props</a></code> | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps">ImageOptimizationProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="cdk-nextjs-standalone.ImageOptimizationLambda.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="cdk-nextjs-standalone.ImageOptimizationLambda.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="cdk-nextjs-standalone.ImageOptimizationLambda.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#cdk-nextjs-standalone.ImageOptimizationProps">ImageOptimizationProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.toString">toString</a></code> | Returns a string representation of this construct. |
+
+---
+
+##### `toString` <a name="toString" id="cdk-nextjs-standalone.ImageOptimizationLambda.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdk-nextjs-standalone.ImageOptimizationLambda.isConstruct"></a>
+
+```typescript
+import { ImageOptimizationLambda } from 'cdk-nextjs-standalone'
+
+ImageOptimizationLambda.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="cdk-nextjs-standalone.ImageOptimizationLambda.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda.property.lambdaFunction">lambdaFunction</a></code> | <code>aws-cdk-lib.aws_lambda.Function</code> | *No description.* |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `bucket`<sup>Required</sup> <a name="bucket" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.bucket"></a>
+
+```typescript
+public readonly bucket: IBucket;
+```
+
+- *Type:* aws-cdk-lib.aws_s3.IBucket
+
+---
+
+##### `lambdaFunction`<sup>Required</sup> <a name="lambdaFunction" id="cdk-nextjs-standalone.ImageOptimizationLambda.property.lambdaFunction"></a>
+
+```typescript
+public readonly lambdaFunction: Function;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.Function
+
+---
+
+
 ### Nextjs <a name="Nextjs" id="cdk-nextjs-standalone.Nextjs"></a>
 
 The `Nextjs` construct is a higher level construct that makes it easy to create a NextJS app.
@@ -102,10 +225,12 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#cdk-nextjs-standalone.Nextjs.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.Bucket</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.Nextjs.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.url">url</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.assetsDeployment">assetsDeployment</a></code> | <code><a href="#cdk-nextjs-standalone.NextJsAssetsDeployment">NextJsAssetsDeployment</a></code> | Asset deployment to S3. |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.distribution">distribution</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsDistribution">NextjsDistribution</a></code> | CloudFront distribution. |
+| <code><a href="#cdk-nextjs-standalone.Nextjs.property.imageOptimizationFunction">imageOptimizationFunction</a></code> | <code><a href="#cdk-nextjs-standalone.ImageOptimizationLambda">ImageOptimizationLambda</a></code> | The image optimization handler lambda function. |
+| <code><a href="#cdk-nextjs-standalone.Nextjs.property.imageOptimizationLambdaFunctionUrl">imageOptimizationLambdaFunctionUrl</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionUrl</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.lambdaFunctionUrl">lambdaFunctionUrl</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionUrl</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built NextJS project output. |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.serverFunction">serverFunction</a></code> | <code><a href="#cdk-nextjs-standalone.NextJsLambda">NextJsLambda</a></code> | The main NextJS server handler lambda function. |
@@ -129,10 +254,10 @@ The tree node.
 ##### `bucket`<sup>Required</sup> <a name="bucket" id="cdk-nextjs-standalone.Nextjs.property.bucket"></a>
 
 ```typescript
-public readonly bucket: Bucket;
+public readonly bucket: IBucket;
 ```
 
-- *Type:* aws-cdk-lib.aws_s3.Bucket
+- *Type:* aws-cdk-lib.aws_s3.IBucket
 
 ---
 
@@ -167,6 +292,28 @@ public readonly distribution: NextjsDistribution;
 - *Type:* <a href="#cdk-nextjs-standalone.NextjsDistribution">NextjsDistribution</a>
 
 CloudFront distribution.
+
+---
+
+##### `imageOptimizationFunction`<sup>Required</sup> <a name="imageOptimizationFunction" id="cdk-nextjs-standalone.Nextjs.property.imageOptimizationFunction"></a>
+
+```typescript
+public readonly imageOptimizationFunction: ImageOptimizationLambda;
+```
+
+- *Type:* <a href="#cdk-nextjs-standalone.ImageOptimizationLambda">ImageOptimizationLambda</a>
+
+The image optimization handler lambda function.
+
+---
+
+##### `imageOptimizationLambdaFunctionUrl`<sup>Required</sup> <a name="imageOptimizationLambdaFunctionUrl" id="cdk-nextjs-standalone.Nextjs.property.imageOptimizationLambdaFunctionUrl"></a>
+
+```typescript
+public readonly imageOptimizationLambdaFunctionUrl: FunctionUrl;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.FunctionUrl
 
 ---
 
@@ -314,7 +461,7 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.NextJsAssetsDeployment.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#cdk-nextjs-standalone.NextJsAssetsDeployment.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.Bucket</code> | Bucket containing assets. |
+| <code><a href="#cdk-nextjs-standalone.NextJsAssetsDeployment.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Bucket containing assets. |
 | <code><a href="#cdk-nextjs-standalone.NextJsAssetsDeployment.property.deployments">deployments</a></code> | <code>aws-cdk-lib.aws_s3_deployment.BucketDeployment[]</code> | Asset deployments to S3. |
 | <code><a href="#cdk-nextjs-standalone.NextJsAssetsDeployment.property.staticTempDir">staticTempDir</a></code> | <code>string</code> | *No description.* |
 
@@ -335,10 +482,10 @@ The tree node.
 ##### `bucket`<sup>Required</sup> <a name="bucket" id="cdk-nextjs-standalone.NextJsAssetsDeployment.property.bucket"></a>
 
 ```typescript
-public readonly bucket: Bucket;
+public readonly bucket: IBucket;
 ```
 
-- *Type:* aws-cdk-lib.aws_s3.Bucket
+- *Type:* aws-cdk-lib.aws_s3.IBucket
 
 Bucket containing assets.
 
@@ -1552,6 +1699,160 @@ public readonly quiet: boolean;
 
 ---
 
+### ImageOptimizationProps <a name="ImageOptimizationProps" id="cdk-nextjs-standalone.ImageOptimizationProps"></a>
+
+#### Initializer <a name="Initializer" id="cdk-nextjs-standalone.ImageOptimizationProps.Initializer"></a>
+
+```typescript
+import { ImageOptimizationProps } from 'cdk-nextjs-standalone'
+
+const imageOptimizationProps: ImageOptimizationProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nextjsPath">nextjsPath</a></code> | <code>string</code> | Relative path to the directory where the NextJS project is located. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.compressionLevel">compressionLevel</a></code> | <code>number</code> | 0 - no compression, fatest 9 - maximum compression, slowest. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | Custom environment variables to pass to the NextJS build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.isPlaceholder">isPlaceholder</a></code> | <code>boolean</code> | Skip building app and deploy a placeholder. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The internal S3 bucket for application images. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built nextJS application. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.lambdaOptions">lambdaOptions</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
+
+---
+
+##### `nextjsPath`<sup>Required</sup> <a name="nextjsPath" id="cdk-nextjs-standalone.ImageOptimizationProps.property.nextjsPath"></a>
+
+```typescript
+public readonly nextjsPath: string;
+```
+
+- *Type:* string
+
+Relative path to the directory where the NextJS project is located.
+
+Can be the root of your project (`.`) or a subdirectory (`packages/web`).
+
+---
+
+##### `compressionLevel`<sup>Optional</sup> <a name="compressionLevel" id="cdk-nextjs-standalone.ImageOptimizationProps.property.compressionLevel"></a>
+
+```typescript
+public readonly compressionLevel: number;
+```
+
+- *Type:* number
+- *Default:* 1
+
+0 - no compression, fatest 9 - maximum compression, slowest.
+
+---
+
+##### `environment`<sup>Optional</sup> <a name="environment" id="cdk-nextjs-standalone.ImageOptimizationProps.property.environment"></a>
+
+```typescript
+public readonly environment: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Custom environment variables to pass to the NextJS build and runtime.
+
+---
+
+##### `isPlaceholder`<sup>Optional</sup> <a name="isPlaceholder" id="cdk-nextjs-standalone.ImageOptimizationProps.property.isPlaceholder"></a>
+
+```typescript
+public readonly isPlaceholder: boolean;
+```
+
+- *Type:* boolean
+
+Skip building app and deploy a placeholder.
+
+Useful when using `next dev` for local development.
+
+---
+
+##### `nodeEnv`<sup>Optional</sup> <a name="nodeEnv" id="cdk-nextjs-standalone.ImageOptimizationProps.property.nodeEnv"></a>
+
+```typescript
+public readonly nodeEnv: string;
+```
+
+- *Type:* string
+
+Optional value for NODE_ENV during build and runtime.
+
+---
+
+##### `quiet`<sup>Optional</sup> <a name="quiet" id="cdk-nextjs-standalone.ImageOptimizationProps.property.quiet"></a>
+
+```typescript
+public readonly quiet: boolean;
+```
+
+- *Type:* boolean
+
+Less build output.
+
+---
+
+##### `tempBuildDir`<sup>Optional</sup> <a name="tempBuildDir" id="cdk-nextjs-standalone.ImageOptimizationProps.property.tempBuildDir"></a>
+
+```typescript
+public readonly tempBuildDir: string;
+```
+
+- *Type:* string
+
+Directory to store temporary build files in.
+
+Defaults to os.tmpdir().
+
+---
+
+##### `bucket`<sup>Required</sup> <a name="bucket" id="cdk-nextjs-standalone.ImageOptimizationProps.property.bucket"></a>
+
+```typescript
+public readonly bucket: IBucket;
+```
+
+- *Type:* aws-cdk-lib.aws_s3.IBucket
+
+The internal S3 bucket for application images.
+
+---
+
+##### `nextBuild`<sup>Required</sup> <a name="nextBuild" id="cdk-nextjs-standalone.ImageOptimizationProps.property.nextBuild"></a>
+
+```typescript
+public readonly nextBuild: NextjsBuild;
+```
+
+- *Type:* <a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a>
+
+Built nextJS application.
+
+---
+
+##### `lambdaOptions`<sup>Optional</sup> <a name="lambdaOptions" id="cdk-nextjs-standalone.ImageOptimizationProps.property.lambdaOptions"></a>
+
+```typescript
+public readonly lambdaOptions: FunctionOptions;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.FunctionOptions
+
+Override function properties.
+
+---
+
 ### NextjsAssetsCachePolicyProps <a name="NextjsAssetsCachePolicyProps" id="cdk-nextjs-standalone.NextjsAssetsCachePolicyProps"></a>
 
 #### Initializer <a name="Initializer" id="cdk-nextjs-standalone.NextjsAssetsCachePolicyProps.Initializer"></a>
@@ -1620,8 +1921,8 @@ const nextjsAssetsDeploymentProps: NextjsAssetsDeploymentProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
+| <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Properties for the S3 bucket containing the NextJS assets. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | The `NextjsBuild` instance representing the built Nextjs application. |
-| <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket \| aws-cdk-lib.aws_s3.BucketProps</code> | Properties for the S3 bucket containing the NextJS assets. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.cachePolicies">cachePolicies</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsAssetsCachePolicyProps">NextjsAssetsCachePolicyProps</a></code> | Override the default S3 cache policies created internally. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.distribution">distribution</a></code> | <code>aws-cdk-lib.aws_cloudfront.IDistribution</code> | Distribution to invalidate when assets change. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.prune">prune</a></code> | <code>boolean</code> | Set to true to delete old assets (defaults to false). |
@@ -1719,6 +2020,18 @@ Defaults to os.tmpdir().
 
 ---
 
+##### `bucket`<sup>Required</sup> <a name="bucket" id="cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.bucket"></a>
+
+```typescript
+public readonly bucket: IBucket;
+```
+
+- *Type:* aws-cdk-lib.aws_s3.IBucket
+
+Properties for the S3 bucket containing the NextJS assets.
+
+---
+
 ##### `nextBuild`<sup>Required</sup> <a name="nextBuild" id="cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.nextBuild"></a>
 
 ```typescript
@@ -1728,20 +2041,6 @@ public readonly nextBuild: NextjsBuild;
 - *Type:* <a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a>
 
 The `NextjsBuild` instance representing the built Nextjs application.
-
----
-
-##### `bucket`<sup>Optional</sup> <a name="bucket" id="cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.bucket"></a>
-
-```typescript
-public readonly bucket: IBucket | BucketProps;
-```
-
-- *Type:* aws-cdk-lib.aws_s3.IBucket | aws-cdk-lib.aws_s3.BucketProps
-
-Properties for the S3 bucket containing the NextJS assets.
-
-You can also supply your own bucket here.
 
 ---
 
@@ -2193,6 +2492,7 @@ const nextjsDistributionProps: NextjsDistributionProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
+| <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.imageOptFunction">imageOptFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | Lambda function to optimize images. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built NextJS app. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.serverFunction">serverFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | Lambda function to route all non-static requests to. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.staticAssetsBucket">staticAssetsBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Bucket containing static assets. |
@@ -2292,6 +2592,20 @@ public readonly tempBuildDir: string;
 Directory to store temporary build files in.
 
 Defaults to os.tmpdir().
+
+---
+
+##### `imageOptFunction`<sup>Required</sup> <a name="imageOptFunction" id="cdk-nextjs-standalone.NextjsDistributionProps.property.imageOptFunction"></a>
+
+```typescript
+public readonly imageOptFunction: IFunction;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.IFunction
+
+Lambda function to optimize images.
+
+Must be provided if you want to serve dynamic requests.
 
 ---
 
@@ -2698,7 +3012,8 @@ const nextjsProps: NextjsProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
-| <code><a href="#cdk-nextjs-standalone.NextjsProps.property.defaults">defaults</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsDefaultsProps">NextjsDefaultsProps</a></code> | Allows you to override defaults for the resources created by this construct. |
+| <code><a href="#cdk-nextjs-standalone.NextjsProps.property.defaults">defaults</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsDefaultsProps">NextjsDefaultsProps</a></code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsProps.property.imageOptimizationBucket">imageOptimizationBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Allows you to override defaults for the resources created by this construct. |
 
 ---
 
@@ -2800,6 +3115,16 @@ public readonly defaults: NextjsDefaultsProps;
 ```
 
 - *Type:* <a href="#cdk-nextjs-standalone.NextjsDefaultsProps">NextjsDefaultsProps</a>
+
+---
+
+##### `imageOptimizationBucket`<sup>Optional</sup> <a name="imageOptimizationBucket" id="cdk-nextjs-standalone.NextjsProps.property.imageOptimizationBucket"></a>
+
+```typescript
+public readonly imageOptimizationBucket: IBucket;
+```
+
+- *Type:* aws-cdk-lib.aws_s3.IBucket
 
 Allows you to override defaults for the resources created by this construct.
 

--- a/API.md
+++ b/API.md
@@ -1721,7 +1721,6 @@ const imageOptimizationProps: ImageOptimizationProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The internal S3 bucket for application images. |
-| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built nextJS application. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.lambdaOptions">lambdaOptions</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
 
 ---
@@ -1826,18 +1825,6 @@ public readonly bucket: IBucket;
 - *Type:* aws-cdk-lib.aws_s3.IBucket
 
 The internal S3 bucket for application images.
-
----
-
-##### `nextBuild`<sup>Required</sup> <a name="nextBuild" id="cdk-nextjs-standalone.ImageOptimizationProps.property.nextBuild"></a>
-
-```typescript
-public readonly nextBuild: NextjsBuild;
-```
-
-- *Type:* <a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a>
-
-Built nextJS application.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -1721,6 +1721,7 @@ const imageOptimizationProps: ImageOptimizationProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The internal S3 bucket for application images. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nextLayer">nextLayer</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsLayer">NextjsLayer</a></code> | NextjsLayer. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.lambdaOptions">lambdaOptions</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
 
 ---
@@ -1825,6 +1826,18 @@ public readonly bucket: IBucket;
 - *Type:* aws-cdk-lib.aws_s3.IBucket
 
 The internal S3 bucket for application images.
+
+---
+
+##### `nextLayer`<sup>Required</sup> <a name="nextLayer" id="cdk-nextjs-standalone.ImageOptimizationProps.property.nextLayer"></a>
+
+```typescript
+public readonly nextLayer: NextjsLayer;
+```
+
+- *Type:* <a href="#cdk-nextjs-standalone.NextjsLayer">NextjsLayer</a>
+
+NextjsLayer.
 
 ---
 
@@ -2848,6 +2861,7 @@ const nextjsLambdaProps: NextjsLambdaProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built nextJS application. |
+| <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.nextLayer">nextLayer</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsLayer">NextjsLayer</a></code> | NextjsLayer. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.lambda">lambda</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
 
 ---
@@ -2952,6 +2966,18 @@ public readonly nextBuild: NextjsBuild;
 - *Type:* <a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a>
 
 Built nextJS application.
+
+---
+
+##### `nextLayer`<sup>Required</sup> <a name="nextLayer" id="cdk-nextjs-standalone.NextjsLambdaProps.property.nextLayer"></a>
+
+```typescript
+public readonly nextLayer: NextjsLayer;
+```
+
+- *Type:* <a href="#cdk-nextjs-standalone.NextjsLayer">NextjsLayer</a>
+
+NextjsLayer.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -1519,7 +1519,6 @@ Any object.
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.buildPath">buildPath</a></code> | <code>string</code> | The path to the directory where the server build artifacts are stored. |
-| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.imagesManifestPath">imagesManifestPath</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextDir">nextDir</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextPublicDir">nextPublicDir</a></code> | <code>string</code> | Public static files. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneBuildDir">nextStandaloneBuildDir</a></code> | <code>string</code> | NextJS project inside of standalone build. |
@@ -1551,16 +1550,6 @@ public readonly buildPath: string;
 - *Type:* string
 
 The path to the directory where the server build artifacts are stored.
-
----
-
-##### `imagesManifestPath`<sup>Required</sup> <a name="imagesManifestPath" id="cdk-nextjs-standalone.NextjsBuild.property.imagesManifestPath"></a>
-
-```typescript
-public readonly imagesManifestPath: string;
-```
-
-- *Type:* string
 
 ---
 
@@ -2651,7 +2640,7 @@ const imageOptimizationProps: ImageOptimizationProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
-| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The internal S3 bucket for application images. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The S3 bucket holding application images. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | The `NextjsBuild` instance representing the built Nextjs application. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nextLayer">nextLayer</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsLayer">NextjsLayer</a></code> | NextjsLayer - sharp runtime. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.lambdaOptions">lambdaOptions</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
@@ -2757,7 +2746,7 @@ public readonly bucket: IBucket;
 
 - *Type:* aws-cdk-lib.aws_s3.IBucket
 
-The internal S3 bucket for application images.
+The S3 bucket holding application images.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ class NextjsSst extends Nextjs {
 
 ## Breaking changes
 
-- v2.0.0: SST wrapper changed, lambda/assets/distribution defaults now are in the `defaults` prop, refactored distribution settings into the new NextjsDistribution construct. If you are upgrading, you must temporarily remove the `customDomain` on your existing 1.x.x app before upgrading to >=2.x.x because the CloudFront distribution will get recreated due to refactoring, and the custom domain must be globally unique across all CloudFront distibutions. Prepare for downtime.
+- v2.0.0: SST wrapper changed, lambda/assets/distribution defaults now are in the `defaults` prop, refactored distribution settings into the new NextjsDistribution construct. If you are upgrading, you must temporarily remove the `customDomain` on your existing 1.x.x app before upgrading to >=2.x.x because the CloudFront distribution will get recreated due to refactoring, and the custom domain must be globally unique across all CloudFront distributions. Prepare for downtime.
 
 ## To-do
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,48 @@ import { Nextjs } from 'cdk-nextjs-standalone';
 
 new Nextjs(this, 'Web', {
   nextjsPath: './web', // relative path to nextjs project root
+
+  // Bucket that contains your app's images for optimizations.
+  // If not provided, internal assets bucket will be used.
+  imageOptimizationBucket: myImageBucket,
 });
+```
+
+### Image Optimization
+
+All requests to `"/_next/image?url=..." ` will be routed to a separate image optimization lambda. To take advantage of this feature, use the `<Image />` component as:
+
+```ts
+// MyPage.tsx
+import Image from 'next/image'
+
+function MyPage() {
+   return (
+      <>
+         <Image src="/path/to/image/in/bucket/hello.png" alt={...} width={...} />
+         <Image src="https://images.unsplash.com/photo-1600804340584-c7db2eacf0bf" alt={...} width={...} />
+      </>
+   )
+}
+```
+
+Note: the `<Image />` component handles the URL encoding and prefixes the `src` with `"/_next/image?url=..."`
+
+If you need to optimize external images, configure `next.config.js`:
+(Please see [doc](https://nextjs.org/docs/api-reference/next/image#remote-patterns) on domain patterns.)
+
+```ts
+// next.config.js
+const nextConfig = {
+  ...
+  images: {
+    remotePatterns: [
+     {
+       hostname: "**.unsplash.com",
+     },
+    ],
+  },
+};
 ```
 
 ## Documentation

--- a/assets/lambda/ImageOptimization.ts
+++ b/assets/lambda/ImageOptimization.ts
@@ -1,0 +1,112 @@
+// Taken from: https://github.com/sladg/nextjs-lambda/blob/master/lib/standalone/image-handler.ts
+// There are other open source MIT libraries we can pick, but this seems the most straightforward
+
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
+import { IncomingMessage, ServerResponse } from 'http'
+import { defaultConfig, NextConfigComplete } from 'next/dist/server/config-shared'
+import { imageOptimizer as nextImageOptimizer, ImageOptimizerCache } from 'next/dist/server/image-optimizer'
+import { NextUrlWithParsedQuery } from 'next/dist/server/request-meta'
+import { ImageConfigComplete } from 'next/dist/shared/lib/image-config'
+import { Readable } from 'stream'
+
+const sourceBucket = process.env.S3_SOURCE_BUCKET ?? undefined
+
+// Handle fetching of S3 object before optimization happens in nextjs.
+const requestHandler =
+	(bucketName: string) =>
+	async (req: IncomingMessage, res: ServerResponse, url?: NextUrlWithParsedQuery): Promise<void> => {
+		if (!url) {
+			throw new Error('URL is missing from request.')
+		}
+
+		// S3 expects keys without leading `/`
+		const trimmedKey = url.href.startsWith('/') ? url.href.substring(1) : url.href
+
+		const client = new S3Client({})
+		const response = await client.send(new GetObjectCommand({ Bucket: bucketName, Key: trimmedKey }))
+
+		if (!response.Body) {
+			throw new Error(`Could not fetch image ${trimmedKey} from bucket.`)
+		}
+
+		const stream = response.Body as Readable
+
+		const data = await new Promise<Buffer>((resolve, reject) => {
+			const chunks: Buffer[] = []
+			stream.on('data', (chunk) => chunks.push(chunk))
+			stream.once('end', () => resolve(Buffer.concat(chunks)))
+			stream.once('error', reject)
+		})
+
+		res.statusCode = 200
+
+		if (response.ContentType) {
+			res.setHeader('Content-Type', response.ContentType)
+		}
+
+		if (response.CacheControl) {
+			res.setHeader('Cache-Control', response.CacheControl)
+		}
+
+		res.write(data)
+		res.end()
+	}
+
+// Make header keys lowercase to ensure integrity.
+const normalizeHeaders = (headers: Record<string, any>) =>
+	Object.entries(headers).reduce((acc, [key, value]) => ({ ...acc, [key.toLowerCase()]: value }), {} as Record<string, string>)
+
+// @TODO: Allow passing params as env vars.
+const nextConfig = {
+	...(defaultConfig as NextConfigComplete),
+	images: {
+		...(defaultConfig.images as ImageConfigComplete),
+		// ...(domains && { domains }),
+		// ...(deviceSizes && { deviceSizes }),
+		// ...(formats && { formats }),
+		// ...(imageSizes && { imageSizes }),
+		// ...(dangerouslyAllowSVG && { dangerouslyAllowSVG }),
+		// ...(contentSecurityPolicy && { contentSecurityPolicy }),
+	},
+}
+
+// We don't need serverless-http neither basePath configuration as endpoint works as single route API.
+// Images are handled via header and query param information.
+const optimizer = async (event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> => {
+	try {
+		if (!sourceBucket) {
+			throw new Error('Bucket name must be defined!')
+		}
+
+		const imageParams = ImageOptimizerCache.validateParams({ headers: event.headers } as any, event.queryStringParameters!, nextConfig, false)
+
+		if ('errorMessage' in imageParams) {
+			throw new Error(imageParams.errorMessage)
+		}
+
+		const optimizedResult = await nextImageOptimizer(
+			{ headers: normalizeHeaders(event.headers) } as any,
+			{} as any, // res object is not necessary as it's not actually used.
+			imageParams,
+			nextConfig,
+			false, // not in dev mode
+			requestHandler(sourceBucket),
+		)
+
+		return {
+			statusCode: 200,
+			body: optimizedResult.buffer.toString('base64'),
+			isBase64Encoded: true,
+			headers: { Vary: 'Accept', 'Content-Type': optimizedResult.contentType },
+		}
+	} catch (error: any) {
+		console.error(error)
+		return {
+			statusCode: 500,
+			body: error?.message || error?.toString() || error,
+		}
+	}
+}
+
+export const handler = optimizer

--- a/assets/lambda/ImageOptimization.ts
+++ b/assets/lambda/ImageOptimization.ts
@@ -7,106 +7,133 @@ import { IncomingMessage, ServerResponse } from 'http'
 import { defaultConfig, NextConfigComplete } from 'next/dist/server/config-shared'
 import { imageOptimizer as nextImageOptimizer, ImageOptimizerCache } from 'next/dist/server/image-optimizer'
 import { NextUrlWithParsedQuery } from 'next/dist/server/request-meta'
-import { ImageConfigComplete } from 'next/dist/shared/lib/image-config'
-import { Readable } from 'stream'
+import { ImageConfigComplete, ImageConfig } from 'next/dist/shared/lib/image-config'
+import { Writable } from 'node:stream'
+import https from 'node:https'
 
 const sourceBucket = process.env.S3_SOURCE_BUCKET ?? undefined
 
+/**
+ * The imageConfig object is stringified and passthrough the lambda as an environment variable
+ */
+const _loadImageConfig = (): ImageConfig => {
+  let imageConfig: ImageConfig = {}
+  const imageConfigString = process.env.NEXT_IMAGE_CONFIG
+  try {
+    imageConfig = JSON.parse(imageConfigString || '{}') as ImageConfig
+  } catch (err) {
+    console.error('Error parsing image config: ', { err, imageConfigString })
+    throw err
+  }
+  return imageConfig
+}
+
+const pipeRes = (p: Writable, res: ServerResponse) => {
+  p.pipe(res)
+  .once('close', () => {
+    res.statusCode = 200
+    res.end()
+  })
+  .once('error', (err) => {
+    console.error('Failed to get image', { err })
+    res.statusCode = 400
+    res.end()
+  })
+}
+
 // Handle fetching of S3 object before optimization happens in nextjs.
 const requestHandler =
-	(bucketName: string) =>
-	async (req: IncomingMessage, res: ServerResponse, url?: NextUrlWithParsedQuery): Promise<void> => {
-		if (!url) {
-			throw new Error('URL is missing from request.')
-		}
+  (bucketName: string) =>
+  async (req: IncomingMessage, res: ServerResponse, url?: NextUrlWithParsedQuery): Promise<void> => {
+    if (!url) {
+      throw new Error('URL is missing from request.')
+    }
 
-		// S3 expects keys without leading `/`
-		const trimmedKey = url.href.startsWith('/') ? url.href.substring(1) : url.href
+    let response: any
+    let data: Buffer
+    // External url, try to fetch image
+    if ( !!url.href?.startsWith('http')) {
+      try {
+        pipeRes(https.get(url), res)
+      } catch (err) {
+        console.error('Failed to get image', err)
+        res.statusCode = 400
+        res.end()
+        return
+      }
+    } else {
+      // S3 expects keys without leading `/`
+      const trimmedKey = url.href.startsWith('/') ? url.href.substring(1) : url.href
 
-		const client = new S3Client({})
-		const response = await client.send(new GetObjectCommand({ Bucket: bucketName, Key: trimmedKey }))
-
-		if (!response.Body) {
-			throw new Error(`Could not fetch image ${trimmedKey} from bucket.`)
-		}
-
-		const stream = response.Body as Readable
-
-		const data = await new Promise<Buffer>((resolve, reject) => {
-			const chunks: Buffer[] = []
-			stream.on('data', (chunk) => chunks.push(chunk))
-			stream.once('end', () => resolve(Buffer.concat(chunks)))
-			stream.once('error', reject)
-		})
-
-		res.statusCode = 200
-
-		if (response.ContentType) {
-			res.setHeader('Content-Type', response.ContentType)
-		}
-
-		if (response.CacheControl) {
-			res.setHeader('Cache-Control', response.CacheControl)
-		}
-
-		res.write(data)
-		res.end()
-	}
+      const client = new S3Client({})
+      response = await client.send(new GetObjectCommand({ Bucket: bucketName, Key: trimmedKey }))
+      if (!response.Body) {
+        throw new Error(`Could not fetch image ${trimmedKey} from bucket.`)
+      }
+      const stream = response.Body as Writable
+      pipeRes(stream, res)
+      
+      if (response.ContentType) {
+        res.setHeader('Content-Type', response.ContentType)
+      }
+      if (response.CacheControl) {
+        res.setHeader('Cache-Control', response.CacheControl)
+      }
+    }
+  }
 
 // Make header keys lowercase to ensure integrity.
 const normalizeHeaders = (headers: Record<string, any>) =>
-	Object.entries(headers).reduce((acc, [key, value]) => ({ ...acc, [key.toLowerCase()]: value }), {} as Record<string, string>)
+  Object.entries(headers).reduce((acc, [key, value]) => ({ ...acc, [key.toLowerCase()]: value }), {} as Record<string, string>)
 
-// @TODO: Allow passing params as env vars.
-const nextConfig = {
-	...(defaultConfig as NextConfigComplete),
-	images: {
-		...(defaultConfig.images as ImageConfigComplete),
-		// ...(domains && { domains }),
-		// ...(deviceSizes && { deviceSizes }),
-		// ...(formats && { formats }),
-		// ...(imageSizes && { imageSizes }),
-		// ...(dangerouslyAllowSVG && { dangerouslyAllowSVG }),
-		// ...(contentSecurityPolicy && { contentSecurityPolicy }),
-	},
+// Load the config from user's app next.config.js passed via env
+const imageConfig = _loadImageConfig()
+
+const nextConfig: NextConfigComplete = {
+  ...(defaultConfig as NextConfigComplete),
+  images: {
+    ...(defaultConfig.images as ImageConfigComplete),
+    domains: imageConfig.domains || [],
+    remotePatterns: imageConfig.remotePatterns || [],
+  },
 }
 
 // We don't need serverless-http neither basePath configuration as endpoint works as single route API.
 // Images are handled via header and query param information.
 const optimizer = async (event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> => {
-	try {
-		if (!sourceBucket) {
-			throw new Error('Bucket name must be defined!')
-		}
+  try {
+    if (!sourceBucket) {
+      throw new Error('Bucket name must be defined!')
+    }
+    // This will reject if the image url is not in the acceptable domains
+    // specified in the user's next.config.js config: `domains` and/or `remotePatterns`
+    const imageParams = ImageOptimizerCache.validateParams({ headers: event.headers } as any, event.queryStringParameters!, nextConfig, false)
+    if ('errorMessage' in imageParams) {
+      throw new Error(imageParams.errorMessage)
+    }
 
-		const imageParams = ImageOptimizerCache.validateParams({ headers: event.headers } as any, event.queryStringParameters!, nextConfig, false)
+    const optimizedResult = await nextImageOptimizer(
+      { headers: normalizeHeaders(event.headers) } as any,
+      {} as any, // res object is not necessary as it's not actually used.
+      imageParams,
+      nextConfig,
+      false, // not in dev mode
+      requestHandler(sourceBucket),
+    )
 
-		if ('errorMessage' in imageParams) {
-			throw new Error(imageParams.errorMessage)
-		}
-
-		const optimizedResult = await nextImageOptimizer(
-			{ headers: normalizeHeaders(event.headers) } as any,
-			{} as any, // res object is not necessary as it's not actually used.
-			imageParams,
-			nextConfig,
-			false, // not in dev mode
-			requestHandler(sourceBucket),
-		)
-
-		return {
-			statusCode: 200,
-			body: optimizedResult.buffer.toString('base64'),
-			isBase64Encoded: true,
-			headers: { Vary: 'Accept', 'Content-Type': optimizedResult.contentType },
-		}
-	} catch (error: any) {
-		console.error(error)
-		return {
-			statusCode: 500,
-			body: error?.message || error?.toString() || error,
-		}
-	}
+    return {
+      statusCode: 200,
+      body: optimizedResult.buffer.toString('base64'),
+      isBase64Encoded: true,
+      headers: { Vary: 'Accept', 'Content-Type': optimizedResult.contentType },
+    }
+  } catch (error: any) {
+    console.error(error)
+    return {
+      statusCode: 500,
+      body: error?.message || error?.toString() || error,
+    }
+  }
 }
 
 export const handler = optimizer

--- a/assets/lambda/ImageOptimization/index.ts
+++ b/assets/lambda/ImageOptimization/index.ts
@@ -61,7 +61,14 @@ const requestHandler =
         throw new Error(`Could not fetch image ${trimmedKey} from bucket.`)
       }
       pipeRes(response.Body, res)
-
+      // Respect the bucket file's content-type and cache-control
+      // nextImageOptimizer will use this to set the results.maxAge
+      if (response.ContentType) {
+        res.setHeader('Content-Type', response.ContentType)
+      }
+      if (response.CacheControl) {
+        res.setHeader('Cache-Control', response.CacheControl)
+      }
     }
   }
 

--- a/assets/lambda/ImageOptimization/index.ts
+++ b/assets/lambda/ImageOptimization/index.ts
@@ -91,7 +91,7 @@ const nextConfig: NextConfigComplete = {
 
 // We don't need serverless-http neither basePath configuration as endpoint works as single route API.
 // Images are handled via header and query param information.
-const optimizer = async (event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> => {
+const optimizer: APIGatewayProxyHandlerV2 = async (event) => {
   try {
     if (!sourceBucket) {
       throw new Error('Bucket name must be defined!')

--- a/assets/lambda/ImageOptimization/index.ts
+++ b/assets/lambda/ImageOptimization/index.ts
@@ -46,7 +46,7 @@ const requestHandler =
     let response: any
     let data: Buffer
     // External url, try to fetch image
-    if ( !!url.href?.startsWith('http')) {
+    if ( !!url.href?.toLowerCase().startsWith('http')) {
       try {
         pipeRes(https.get(url), res)
       } catch (err) {

--- a/assets/lambda/NextJsHandler.ts
+++ b/assets/lambda/NextJsHandler.ts
@@ -10,10 +10,10 @@ import fs from 'node:fs';
 import { IncomingMessage, ServerResponse } from 'node:http';
 import path from 'node:path';
 import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
-import type { NextConfig } from 'next';
 import type { Options } from 'next/dist/server/next-server';
 import * as nss from 'next/dist/server/next-server';
 import slsHttp from 'serverless-http';
+import { getNextServerConfig } from './utils'
 
 const getErrMessage = (e: any) => ({ message: 'Server failed to respond.', details: e });
 
@@ -28,7 +28,8 @@ const NextNodeServer: typeof nss.default = (nss.default as any)?.default ?? nss.
 const nextDir = path.join(__dirname, '.next');
 const requiredServerFilesPath = path.join(nextDir, 'required-server-files.json');
 const json = fs.readFileSync(requiredServerFilesPath, 'utf-8');
-const requiredServerFiles = JSON.parse(json) as { version: number; config: NextConfig };
+const { config: nextConfig } = getNextServerConfig()
+
 const config: Options = {
   // hostname and port must be defined for proxying to work (middleware)
   hostname: 'localhost',
@@ -36,7 +37,7 @@ const config: Options = {
   // Next.js compression should be disabled because of a bug
   // in the bundled `compression` package. See:
   // https://github.com/vercel/next.js/issues/11669
-  conf: { ...requiredServerFiles.config, compress: false },
+  conf: { ...nextConfig, compress: false },
   customServer: false,
   dev: false,
   dir: __dirname,

--- a/assets/lambda/utils.ts
+++ b/assets/lambda/utils.ts
@@ -1,0 +1,13 @@
+import path from 'node:path'
+import fs from "node:fs"
+import type { NextConfig } from 'next'
+
+/**
+ * Returns the generated nextjs server files JSON object in the ".next" folder
+ */
+export function getNextServerConfig() {
+  const nextDir = path.join(__dirname, '.next');
+  const requiredServerFilesPath = path.join(nextDir, 'required-server-files.json');
+  const json = fs.readFileSync(requiredServerFilesPath, 'utf-8');
+  return JSON.parse(json) as { version: number, config: NextConfig };
+}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "constructs": "^10.0.5"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.218.0",
     "@types/aws-lambda": "^8.10.109",
     "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^9.0.13",
@@ -80,11 +79,9 @@
     "indent-string": "*",
     "jszip": "^3.10.1",
     "micromatch": "^4.0.5",
-    "next": "^13.0.4",
     "serverless-http": "^3.1.0"
   },
   "bundledDependencies": [
-    "@aws-sdk/client-s3",
     "@types/aws-lambda",
     "@types/cross-spawn",
     "@types/fs-extra",
@@ -97,7 +94,6 @@
     "indent-string",
     "jszip",
     "micromatch",
-    "next",
     "serverless-http"
   ],
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.50.0",
+    "aws-cdk-lib": "2.53.0",
     "aws-sdk": "^2.1266.0",
     "constructs": "10.0.5",
     "eslint": "^8",
@@ -55,19 +55,19 @@
     "jsii-docgen": "^7.0.163",
     "jsii-pacmak": "^1.71.0",
     "json-schema": "^0.4.0",
-    "next": "^13.0.5",
     "npm-check-updates": "^16",
     "prettier": "^2.8.0",
     "projen": "^0.65.43",
     "standard-version": "^9",
     "ts-jest": "^27",
-    "typescript": "^4.9.3"
+    "typescript": "4.9.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.50.0",
+    "aws-cdk-lib": "^2.53.0",
     "constructs": "^10.0.5"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.223.0",
     "@types/aws-lambda": "^8.10.109",
     "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^9.0.13",
@@ -83,6 +83,7 @@
     "serverless-http": "^3.1.0"
   },
   "bundledDependencies": [
+    "@aws-sdk/client-s3",
     "@types/aws-lambda",
     "@types/cross-spawn",
     "@types/fs-extra",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "jsii-docgen": "^7.0.163",
     "jsii-pacmak": "^1.71.0",
     "json-schema": "^0.4.0",
+    "next": "^13.0.5",
     "npm-check-updates": "^16",
     "prettier": "^2.8.0",
     "projen": "^0.65.43",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "constructs": "^10.0.5"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.218.0",
     "@types/aws-lambda": "^8.10.109",
     "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^9.0.13",
@@ -79,9 +80,11 @@
     "indent-string": "*",
     "jszip": "^3.10.1",
     "micromatch": "^4.0.5",
+    "next": "^13.0.4",
     "serverless-http": "^3.1.0"
   },
   "bundledDependencies": [
+    "@aws-sdk/client-s3",
     "@types/aws-lambda",
     "@types/cross-spawn",
     "@types/fs-extra",
@@ -94,6 +97,7 @@
     "indent-string",
     "jszip",
     "micromatch",
+    "next",
     "serverless-http"
   ],
   "keywords": [

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -1,0 +1,120 @@
+import * as os from 'os';
+import * as path from 'path';
+import { Duration } from 'aws-cdk-lib';
+import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Function, FunctionOptions } from 'aws-cdk-lib/aws-lambda';
+import { IBucket } from 'aws-cdk-lib/aws-s3';
+import * as s3Assets from 'aws-cdk-lib/aws-s3-assets';
+
+import { Construct } from 'constructs';
+import * as fs from 'fs-extra';
+import { bundleFunction } from './BundleFunction';
+import { NextjsBaseProps } from './NextjsBase';
+import { createArchive, NextjsBuild } from './NextjsBuild';
+import { NextjsLayer } from './NextjsLayer';
+export interface ImageOptimizationProps extends NextjsBaseProps {
+  /**
+   * The internal S3 bucket for application images.
+   */
+  readonly bucket: IBucket;
+  /**
+   * Built nextJS application.
+   */
+  readonly nextBuild: NextjsBuild;
+
+  /**
+   * Override function properties.
+   */
+  readonly lambdaOptions?: FunctionOptions;
+}
+
+const RUNTIME = lambda.Runtime.NODEJS_16_X;
+
+/**
+ * This lambda handles image optimization.
+ */
+export class ImageOptimizationLambda extends Construct {
+  bucket: IBucket;
+  lambdaFunction: Function;
+
+  constructor(scope: Construct, id: string, props: ImageOptimizationProps) {
+    super(scope, id);
+    const { nextBuild, lambdaOptions, bucket } = props;
+    this.bucket = bucket;
+
+    // build our server handler in build.nextStandaloneDir
+    const serverHandler = path.resolve(__dirname, '../assets/lambda/ImageOptimization.ts');
+    // server should live in the same dir as the nextjs app to access deps properly
+    const serverPath = path.join(props.nextjsPath, 'server.cjs');
+    bundleFunction({
+      inputPath: serverHandler,
+      outputPath: path.join(nextBuild.nextStandaloneDir, serverPath),
+      bundleOptions: {
+        bundle: true,
+        minify: false,
+        sourcemap: true,
+        target: 'node16',
+        platform: 'node',
+        external: ['sharp', 'next', 'aws-sdk'],
+        format: 'cjs', // hope one day we can use esm
+      },
+    });
+
+    // zip up the standalone directory
+    const zipOutDir = path.resolve(
+      props.tempBuildDir
+        ? path.resolve(path.join(props.tempBuildDir, `imageOptimization`))
+        : fs.mkdtempSync(path.join(os.tmpdir(), 'imageOptimization-'))
+    );
+    const zipFilePath = createArchive({
+      directory: nextBuild.nextStandaloneDir,
+      zipFileName: 'imageOptimization.zip',
+      zipOutDir,
+      fileGlob: '*',
+      quiet: props.quiet,
+    });
+
+    if (!zipFilePath) throw new Error('Failed to create archive for image optimization lambda function code');
+
+    // build native deps layer
+    const nextLayer = new NextjsLayer(scope, 'ImageOptimizationLayer', {});
+
+    // upload the lambda package to S3
+    const s3asset = new s3Assets.Asset(scope, 'ImageOptimizationFnAsset', { path: zipFilePath });
+    const code = lambda.Code.fromBucket(s3asset.bucket, s3asset.s3ObjectKey);
+
+    // build the lambda function
+    const fn = new Function(scope, 'ImageOptimizationHandler', {
+      memorySize: lambdaOptions?.memorySize || 1024,
+      timeout: lambdaOptions?.timeout ?? Duration.seconds(10),
+      runtime: RUNTIME,
+      handler: path.join(props.nextjsPath, 'server.handler'),
+      layers: [nextLayer],
+      code,
+      environment: {
+        S3_SOURCE_BUCKET: this.bucket.bucketName,
+      },
+      ...lambdaOptions,
+    });
+    this.lambdaFunction = fn;
+
+    this.addPolicy();
+  }
+
+  /**
+   * Adds policy statement to give GetObject permission Image Optimization lambda.
+   */
+  private addPolicy(): void {
+    const policyStatement = new PolicyStatement({
+      actions: ['s3:GetObject'],
+      resources: [this.bucket.arnForObjects('*')],
+    });
+
+    this.lambdaFunction.role?.attachInlinePolicy(
+      new Policy(this, 'get-image-policy', {
+        statements: [policyStatement],
+      })
+    );
+  }
+}

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -78,7 +78,12 @@ export class ImageOptimizationLambda extends NodejsFunction {
       bundling: {
         commandHooks: {
           beforeBundling(inputDir: string, outputDir: string): string[] {
-            return [`echo '${data}' > ${inputDir}/${configFile}`, `cp ${inputDir}/${configFile} ${outputDir}`];
+            // Saves the required-server-files.json to the .next folder
+            return [
+              `echo '${data}' > ${inputDir}/${configFile}`,
+              `mkdir ${outputDir}/.next`,
+              `cp ${inputDir}/${configFile} ${outputDir}/.next`,
+            ];
           },
           afterBundling() {
             return [];

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -108,6 +108,8 @@ export class ImageOptimizationLambda extends NodejsFunction {
 
     this.bucket = bucket;
     this.addPolicy();
+
+    fs.rmSync(modulesPath, { recursive: true, force: true });
   }
 
   /**

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -80,8 +80,12 @@ export class ImageOptimizationLambda extends NodejsFunction {
           beforeBundling(inputDir: string, outputDir: string): string[] {
             return [`echo '${data}' > ${inputDir}/${configFile}`, `cp ${inputDir}/${configFile} ${outputDir}`];
           },
-          afterBundling() { return [] },
-          beforeInstall() { return [] },
+          afterBundling() {
+            return [];
+          },
+          beforeInstall() {
+            return [];
+          },
         },
         minify: true,
         target: 'node18',

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -8,6 +8,7 @@ import { IBucket } from 'aws-cdk-lib/aws-s3';
 
 import { Construct } from 'constructs';
 import { NextjsBaseProps } from './NextjsBase';
+import { NextjsLayer } from './NextjsLayer';
 export interface ImageOptimizationProps extends NextjsBaseProps {
   /**
    * The internal S3 bucket for application images.
@@ -18,6 +19,11 @@ export interface ImageOptimizationProps extends NextjsBaseProps {
    * Override function properties.
    */
   readonly lambdaOptions?: FunctionOptions;
+
+  /**
+   * NextjsLayer
+   */
+  readonly nextLayer: NextjsLayer;
 }
 
 const RUNTIME = lambda.Runtime.NODEJS_16_X;
@@ -38,6 +44,11 @@ export class ImageOptimizationLambda extends Construct {
     this.lambdaFunction = new NodejsFunction(this, 'ImageOptimizationHandler', {
       entry: imageOptHandlerPath,
       runtime: RUNTIME,
+      bundling: {
+        minify: true,
+        target: 'node16',
+      },
+      layers: [props.nextLayer],
       ...lambdaOptions,
       // defaults
       memorySize: lambdaOptions?.memorySize || 1024,

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -1,27 +1,18 @@
-import * as os from 'os';
 import * as path from 'path';
 import { Duration } from 'aws-cdk-lib';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Function, FunctionOptions } from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
-import * as s3Assets from 'aws-cdk-lib/aws-s3-assets';
 
 import { Construct } from 'constructs';
-import * as fs from 'fs-extra';
-import { bundleFunction } from './BundleFunction';
 import { NextjsBaseProps } from './NextjsBase';
-import { createArchive, NextjsBuild } from './NextjsBuild';
-import { NextjsLayer } from './NextjsLayer';
 export interface ImageOptimizationProps extends NextjsBaseProps {
   /**
    * The internal S3 bucket for application images.
    */
   readonly bucket: IBucket;
-  /**
-   * Built nextJS application.
-   */
-  readonly nextBuild: NextjsBuild;
 
   /**
    * Override function properties.
@@ -40,64 +31,22 @@ export class ImageOptimizationLambda extends Construct {
 
   constructor(scope: Construct, id: string, props: ImageOptimizationProps) {
     super(scope, id);
-    const { nextBuild, lambdaOptions, bucket } = props;
+    const { lambdaOptions, bucket } = props;
     this.bucket = bucket;
 
-    // build our server handler in build.nextStandaloneDir
-    const serverHandler = path.resolve(__dirname, '../assets/lambda/ImageOptimization.ts');
-    // server should live in the same dir as the nextjs app to access deps properly
-    const serverPath = path.join(props.nextjsPath, 'server.cjs');
-    bundleFunction({
-      inputPath: serverHandler,
-      outputPath: path.join(nextBuild.nextStandaloneDir, serverPath),
-      bundleOptions: {
-        bundle: true,
-        minify: false,
-        sourcemap: true,
-        target: 'node16',
-        platform: 'node',
-        external: ['sharp', 'next', 'aws-sdk'],
-        format: 'cjs', // hope one day we can use esm
-      },
-    });
-
-    // zip up the standalone directory
-    const zipOutDir = path.resolve(
-      props.tempBuildDir
-        ? path.resolve(path.join(props.tempBuildDir, `imageOptimization`))
-        : fs.mkdtempSync(path.join(os.tmpdir(), 'imageOptimization-'))
-    );
-    const zipFilePath = createArchive({
-      directory: nextBuild.nextStandaloneDir,
-      zipFileName: 'imageOptimization.zip',
-      zipOutDir,
-      fileGlob: '*',
-      quiet: props.quiet,
-    });
-
-    if (!zipFilePath) throw new Error('Failed to create archive for image optimization lambda function code');
-
-    // build native deps layer
-    const nextLayer = new NextjsLayer(scope, 'ImageOptimizationLayer', {});
-
-    // upload the lambda package to S3
-    const s3asset = new s3Assets.Asset(scope, 'ImageOptimizationFnAsset', { path: zipFilePath });
-    const code = lambda.Code.fromBucket(s3asset.bucket, s3asset.s3ObjectKey);
-
-    // build the lambda function
-    const fn = new Function(scope, 'ImageOptimizationHandler', {
+    const imageOptHandlerPath = path.resolve(__dirname, '../assets/lambda/ImageOptimization.ts');
+    this.lambdaFunction = new NodejsFunction(this, 'ImageOptimizationHandler', {
+      entry: imageOptHandlerPath,
+      runtime: RUNTIME,
+      ...lambdaOptions,
+      // defaults
       memorySize: lambdaOptions?.memorySize || 1024,
       timeout: lambdaOptions?.timeout ?? Duration.seconds(10),
-      runtime: RUNTIME,
-      handler: path.join(props.nextjsPath, 'server.handler'),
-      layers: [nextLayer],
-      code,
       environment: {
+        ...lambdaOptions?.environment,
         S3_SOURCE_BUCKET: this.bucket.bucketName,
       },
-      ...lambdaOptions,
     });
-    this.lambdaFunction = fn;
 
     this.addPolicy();
   }

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -21,7 +21,7 @@ export type RemotePattern = {
 
 export interface ImageOptimizationProps extends NextjsBaseProps {
   /**
-   * The internal S3 bucket for application images.
+   * The S3 bucket holding application images.
    */
   readonly bucket: IBucket;
 

--- a/src/Nextjs.ts
+++ b/src/Nextjs.ts
@@ -12,6 +12,7 @@ import { BaseSiteDomainProps, NextjsBaseProps } from './NextjsBase';
 import { NextjsBuild } from './NextjsBuild';
 import { NextjsDistribution, NextjsDistributionProps } from './NextjsDistribution';
 import { NextJsLambda } from './NextjsLambda';
+import { NextjsLayer } from './NextjsLayer';
 
 // contains server-side resolved environment vars in config bucket
 export const CONFIG_ENV_JSON_PATH = 'next-env.json';
@@ -123,10 +124,14 @@ export class Nextjs extends Construct {
         autoDeleteObjects: true,
       });
 
+    // layer
+    const nextLayer = new NextjsLayer(scope, 'NextjsLayer', {});
+
     // build nextjs app
     this.nextBuild = new NextjsBuild(this, id, { ...props, tempBuildDir });
     this.serverFunction = new NextJsLambda(this, 'Fn', {
       ...props,
+      nextLayer,
       tempBuildDir,
       nextBuild: this.nextBuild,
       lambda: props.defaults?.lambda,
@@ -134,6 +139,7 @@ export class Nextjs extends Construct {
     // build image optimization
     this.imageOptimizationFunction = new ImageOptimizationLambda(this, 'ImgOptFn', {
       ...props,
+      nextLayer,
       lambdaOptions: props.defaults?.lambda,
       bucket: props.imageOptimizationBucket || this.bucket,
     });

--- a/src/Nextjs.ts
+++ b/src/Nextjs.ts
@@ -134,7 +134,6 @@ export class Nextjs extends Construct {
     // build image optimization
     this.imageOptimizationFunction = new ImageOptimizationLambda(this, 'ImgOptFn', {
       ...props,
-      nextBuild: this.nextBuild,
       lambdaOptions: props.defaults?.lambda,
       bucket: props.imageOptimizationBucket || this.bucket,
     });

--- a/src/Nextjs.ts
+++ b/src/Nextjs.ts
@@ -128,7 +128,7 @@ export class Nextjs extends Construct {
       });
 
     // layer
-    const nextLayer = new NextjsLayer(scope, 'NextjsLayer3', {});
+    const nextLayer = new NextjsLayer(scope, 'NextjsLayer', {});
 
     // build nextjs app
     this.nextBuild = new NextjsBuild(this, id, { ...props, tempBuildDir });

--- a/src/Nextjs.ts
+++ b/src/Nextjs.ts
@@ -103,7 +103,7 @@ export class Nextjs extends Construct {
   public lambdaFunctionUrl!: lambda.FunctionUrl;
   public imageOptimizationLambdaFunctionUrl!: lambda.FunctionUrl;
 
-  protected staticAssetBucket: s3.Bucket;
+  protected staticAssetBucket: s3.IBucket;
 
   constructor(scope: Construct, id: string, props: NextjsProps) {
     super(scope, id);

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -55,7 +55,6 @@ export class NextjsBuild extends Construct {
   public tempBuildDir: string;
 
   public nextDir: string;
-  public imagesManifestPath: string;
 
   constructor(scope: Construct, id: string, props: NextjsBuildProps) {
     super(scope, id);
@@ -83,12 +82,8 @@ export class NextjsBuild extends Construct {
     this.nextStandaloneBuildDir = this._getNextStandaloneBuildDir();
     this.nextPublicDir = this._getNextPublicDir();
     this.nextStaticDir = this._getNextStaticDir();
-
     this.buildPath = this.nextStandaloneBuildDir;
-
     this.nextDir = this._getNextDir();
-    // image manifest
-    this.imagesManifestPath = this._getImagesManifestPath();
   }
 
   private runNpmBuild() {
@@ -201,9 +196,7 @@ export class NextjsBuild extends Construct {
   private _getNextPublicDir() {
     return path.join(this._getNextDir(), NEXTJS_PUBLIC_DIR);
   }
-  private _getImagesManifestPath() {
-    return path.join(this._getNextDir(), IMAGE_MANIFEST_FILE);
-  }
+
 }
 
 export interface CreateArchiveArgs {

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -4,7 +4,6 @@ import { Token } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as spawn from 'cross-spawn';
 import * as fs from 'fs-extra';
-import * as glob from 'glob';
 import { listDirectory } from './NextjsAssetsDeployment';
 import { CompressionLevel, NextjsBaseProps } from './NextjsBase';
 
@@ -125,24 +124,6 @@ export class NextjsBuild extends Construct {
     });
     if (buildResult.status !== 0) {
       throw new Error('The app "build" script failed.');
-    }
-
-    // cleanup
-    // delete the `sharp` module since it's provided by the lambda layer
-    const sharpPathNpm = path.join(this._getNextStandaloneDir(), 'node_modules', 'sharp'); // npm/yarn
-    if (fs.existsSync(sharpPathNpm)) {
-      // delete the sharp folder
-      if (!this.props.quiet) console.debug('├ Deleting sharp module from', sharpPathNpm);
-      fs.removeSync(sharpPathNpm);
-    }
-    // is there a `sharp@x.y.z` folder in the `node_modules/.pnpm` folder?
-    const pnpmModulesDir = path.join(this._getNextStandaloneDir(), 'node_modules', '.pnpm'); // pnpm
-    // get glob pattern for sharp version
-    const matches = glob.sync(path.join(pnpmModulesDir, 'sharp@*'));
-    if (matches.length > 0) {
-      // delete the sharp folder
-      if (!this.props.quiet) console.debug('├ Deleting sharp module from', matches[0]);
-      fs.removeSync(matches[0]);
     }
   }
 

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -54,6 +54,9 @@ export class NextjsBuild extends Construct {
 
   public tempBuildDir: string;
 
+  public nextDir: string;
+  public imagesManifestPath: string;
+
   constructor(scope: Construct, id: string, props: NextjsBuildProps) {
     super(scope, id);
 
@@ -82,6 +85,10 @@ export class NextjsBuild extends Construct {
     this.nextStaticDir = this._getNextStaticDir();
 
     this.buildPath = this.nextStandaloneBuildDir;
+
+    this.nextDir = this._getNextDir();
+    // image manifest
+    this.imagesManifestPath = this._getImagesManifestPath();
   }
 
   private runNpmBuild() {
@@ -193,6 +200,9 @@ export class NextjsBuild extends Construct {
   }
   private _getNextPublicDir() {
     return path.join(this._getNextDir(), NEXTJS_PUBLIC_DIR);
+  }
+  private _getImagesManifestPath() {
+    return path.join(this._getNextDir(), IMAGE_MANIFEST_FILE);
   }
 }
 

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -196,7 +196,6 @@ export class NextjsBuild extends Construct {
   private _getNextPublicDir() {
     return path.join(this._getNextDir(), NEXTJS_PUBLIC_DIR);
   }
-
 }
 
 export interface CreateArchiveArgs {

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -436,7 +436,6 @@ export class NextjsDistribution extends Construct {
           compress: true,
           cachePolicy: imageCachePolicy,
           originRequestPolicy: imageOptORP,
-          responseHeadersPolicy: staticResponseHeadersPolicy,
         },
 
         // known static routes

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -311,11 +311,7 @@ export class NextjsDistribution extends Construct {
     const imageOptFnUrl = this.props.imageOptFunction.addFunctionUrl({
       authType: lambda.FunctionUrlAuthType.NONE,
     });
-    const imageOptFunctionOrigin = new origins.HttpOrigin(Fn.parseDomainName(imageOptFnUrl.url), {
-      customHeaders: {
-        'x-origin-url': imageOptFnUrl.url,
-      },
-    });
+    const imageOptFunctionOrigin = new origins.HttpOrigin(Fn.parseDomainName(imageOptFnUrl.url));
     const imageOptORP = new cloudfront.OriginRequestPolicy(this, 'ImageOptPolicy', {
       queryStringBehavior: cloudfront.OriginRequestQueryStringBehavior.allowList('q', 'w', 'url'),
       headerBehavior: cloudfront.OriginRequestHeaderBehavior.allowList('accept'),

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -60,6 +60,12 @@ export interface NextjsDistributionProps extends NextjsBaseProps {
   readonly serverFunction: lambda.IFunction;
 
   /**
+   * Lambda function to optimize images.
+   * Must be provided if you want to serve dynamic requests.
+   */
+  readonly imageOptFunction: lambda.IFunction;
+
+  /**
    * Overrides for created CDK resources.
    */
   readonly cdk?: NextjsDistributionCdkProps;
@@ -294,12 +300,26 @@ export class NextjsDistribution extends Construct {
     const fnUrl = this.props.serverFunction.addFunctionUrl({
       authType: lambda.FunctionUrlAuthType.NONE,
     });
-    // this.lambdaFunctionUrl = fnUrl;
     const serverFunctionOrigin = new origins.HttpOrigin(Fn.parseDomainName(fnUrl.url), {
       customHeaders: {
         // provide config to edge lambda function
         'x-origin-url': fnUrl.url,
       },
+    });
+
+    // Image Optimization
+    const imageOptFnUrl = this.props.imageOptFunction.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.NONE,
+    });
+    const imageOptFunctionOrigin = new origins.HttpOrigin(Fn.parseDomainName(imageOptFnUrl.url), {
+      customHeaders: {
+        'x-origin-url': imageOptFnUrl.url,
+      },
+    });
+    const imageOptORP = new cloudfront.OriginRequestPolicy(this, 'ImageOptPolicy', {
+      queryStringBehavior: cloudfront.OriginRequestQueryStringBehavior.allowList('q', 'w', 'url'),
+      headerBehavior: cloudfront.OriginRequestHeaderBehavior.allowList('accept'),
+      cookieBehavior: cloudfront.OriginRequestCookieBehavior.none(),
     });
 
     // lambda behavior edge function
@@ -414,12 +434,12 @@ export class NextjsDistribution extends Construct {
         // dynamic images go to lambda
         '_next/image*': {
           viewerProtocolPolicy,
-          origin: serverFunctionOrigin,
+          origin: imageOptFunctionOrigin,
           allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
           cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
           compress: true,
           cachePolicy: imageCachePolicy,
-          originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER, // not sure what goes here
+          originRequestPolicy: imageOptORP,
         },
 
         // known static routes

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -436,6 +436,7 @@ export class NextjsDistribution extends Construct {
           compress: true,
           cachePolicy: imageCachePolicy,
           originRequestPolicy: imageOptORP,
+          responseHeadersPolicy: staticResponseHeadersPolicy,
         },
 
         // known static routes

--- a/src/NextjsLambda.ts
+++ b/src/NextjsLambda.ts
@@ -38,6 +38,11 @@ export interface NextjsLambdaProps extends NextjsBaseProps {
    * Override function properties.
    */
   readonly lambda?: FunctionOptions;
+
+  /**
+   * NextjsLayer
+   */
+  readonly nextLayer: NextjsLayer;
 }
 
 const RUNTIME = lambda.Runtime.NODEJS_16_X;
@@ -93,9 +98,6 @@ export class NextJsLambda extends Construct {
     });
     if (!zipFilePath) throw new Error('Failed to create archive for lambda function code');
 
-    // build native deps layer
-    const nextLayer = new NextjsLayer(scope, 'NextjsLayer', {});
-
     // upload the lambda package to S3
     const s3asset = new s3Assets.Asset(scope, 'MainFnAsset', { path: zipFilePath });
     const code = isPlaceholder
@@ -111,7 +113,7 @@ export class NextJsLambda extends Construct {
       timeout: functionOptions?.timeout ?? Duration.seconds(10),
       runtime: RUNTIME,
       handler: path.join(props.nextjsPath, 'server.handler'),
-      layers: [nextLayer],
+      layers: [props.nextLayer],
       code,
       environment,
 

--- a/src/NextjsLambda.ts
+++ b/src/NextjsLambda.ts
@@ -13,7 +13,6 @@ import { bundleFunction } from './BundleFunction';
 import { CONFIG_ENV_JSON_PATH } from './Nextjs';
 import { NextjsBaseProps } from './NextjsBase';
 import { createArchive, NextjsBuild } from './NextjsBuild';
-import { NextjsLayer } from './NextjsLayer';
 import { getS3ReplaceValues, NextjsS3EnvRewriter } from './NextjsS3EnvRewriter';
 
 export type EnvironmentVars = Record<string, string>;
@@ -38,11 +37,6 @@ export interface NextjsLambdaProps extends NextjsBaseProps {
    * Override function properties.
    */
   readonly lambda?: FunctionOptions;
-
-  /**
-   * NextjsLayer
-   */
-  readonly nextLayer: NextjsLayer;
 }
 
 const RUNTIME = lambda.Runtime.NODEJS_16_X;
@@ -78,7 +72,7 @@ export class NextJsLambda extends Construct {
         sourcemap: true,
         target: 'node16',
         platform: 'node',
-        external: ['sharp', 'next', 'aws-sdk'],
+        external: ['next', 'aws-sdk'],
         format: 'cjs', // hope one day we can use esm
       },
     });
@@ -113,7 +107,6 @@ export class NextJsLambda extends Construct {
       timeout: functionOptions?.timeout ?? Duration.seconds(10),
       runtime: RUNTIME,
       handler: path.join(props.nextjsPath, 'server.handler'),
-      layers: [props.nextLayer],
       code,
       environment,
 

--- a/src/NextjsLayer.ts
+++ b/src/NextjsLayer.ts
@@ -16,8 +16,8 @@ export class NextjsLayer extends LayerVersion {
     const layerDir = path.resolve(__dirname, '../assets');
     super(scope, id, {
       code: new lambda.AssetCode(path.join(layerDir, 'sharp-0.30.0.zip')),
-      compatibleRuntimes: [lambda.Runtime.NODEJS_16_X],
-      description: 'Sharp for NextJS',
+      compatibleRuntimes: [lambda.Runtime.NODEJS_16_X, lambda.Runtime.NODEJS_18_X],
+      description: 'Sharp for Lambdas',
       ...props,
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
 } from './NextjsAssetsDeployment';
 export { NextjsBuild, NextjsBuildProps, CreateArchiveArgs } from './NextjsBuild';
 export { EnvironmentVars, NextJsLambda, NextjsLambdaProps } from './NextjsLambda';
+export { ImageOptimizationLambda, ImageOptimizationProps } from './ImageOptimizationLambda';
 export { NextjsLayer, NextjsLayerProps } from './NextjsLayer';
 export {
   NextjsDistribution,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,972 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@aws-cdk/asset-awscli-v1@^2.2.9":
+  version "2.2.26"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.26.tgz#4d1f36915ef6046b728a61be19d689e1128b0bf7"
+  integrity sha512-j6bp4iDIZlqAlmACpBCZuCZjLYNeJccQFAPmvgjG9edLBGvVyJZvBT7m39lVtjfEyl8EyznCv7czOFaKsZH2Zg==
+
+"@aws-cdk/asset-kubectl-v20@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz#d01c1efb867fb7f2cfd8c8b230b8eae16447e156"
+  integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
+
+"@aws-cdk/asset-node-proxy-agent-v5@^2.0.15":
+  version "2.0.32"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.32.tgz#9ee62c3b709c8fc4c4e348e6a980a7d06b9290e6"
+  integrity sha512-w1MaBSyR1vT+glPBNd0smp9MPWbz1z/o3+N59MYpjtA4lW845hb8LwthzvbPUzb0YglUfrnOj64i9BFe6BXeZA==
+
+"@aws-crypto/crc32@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-2.0.0.tgz#4ad432a3c03ec3087c5540ff6e41e6565d2dc153"
+  integrity sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/crc32c@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz#4235336ef78f169f6a05248906703b9b78da676e"
+  integrity sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/ie11-detection@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz#9c39f4a5558196636031a933ec1b4792de959d6a"
+  integrity sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/sha1-browser@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz#71e735df20ea1d38f59259c4b1a2e00ca74a0eea"
+  integrity sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^2.0.0"
+    "@aws-crypto/supports-web-crypto" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-browser@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz#741c9024df55ec59b51e5b1f5d806a4852699fb5"
+  integrity sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^2.0.0"
+    "@aws-crypto/sha256-js" "^2.0.0"
+    "@aws-crypto/supports-web-crypto" "^2.0.0"
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz#f1f936039bdebd0b9e2dd834d65afdc2aac4efcb"
+  integrity sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.2.tgz#c81e5d378b8a74ff1671b58632779986e50f4c99"
+  integrity sha512-iXLdKH19qPmIC73fVCrHWCSYjN/sxaAvZ3jNNyw6FclmHyjLKg0f69WlC9KTnyElxCR5MO9SKaG00VwlJwyAkQ==
+  dependencies:
+    "@aws-crypto/util" "^2.0.2"
+    "@aws-sdk/types" "^3.110.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/supports-web-crypto@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz#9f02aafad8789cac9c0ab5faaebb1ab8aa841338"
+  integrity sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^2.0.0", "@aws-crypto/util@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-2.0.2.tgz#adf5ff5dfbc7713082f897f1d01e551ce0edb9c0"
+  integrity sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==
+  dependencies:
+    "@aws-sdk/types" "^3.110.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-sdk/abort-controller@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-3.222.0.tgz#7a93065dd3cbb6013b00ccb380d59ae9589d9942"
+  integrity sha512-Ric2vJQEWrzz915wBeZlYLWAnIsnywOcZpzroPVTY/TNKRvM0GcSPVuD9vv1lOwybVnDHsipukzwQBAZXkNWVA==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/chunked-blob-reader-native@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz#cdbd12c89a4f3ddd91bf707da8bb4af311487cc5"
+  integrity sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==
+  dependencies:
+    "@aws-sdk/util-base64" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/chunked-blob-reader@3.188.0":
+  version "3.188.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz#18181b27511ab512e56b9f2cef30d2abbef639dc"
+  integrity sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/client-s3@^3.223.0":
+  version "3.223.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.223.0.tgz#d741b59434d26f89a21d7a8dc3b8ee028a646902"
+  integrity sha512-hIQfiseFXf04jz14iyQhfV9eRz9XgiMihl9oQhKs3CpL7bFGkhCkCIwbqUrsheqcD1O2wcOSKTAt6QdYbDyhzg==
+  dependencies:
+    "@aws-crypto/sha1-browser" "2.0.0"
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/client-sts" "3.223.0"
+    "@aws-sdk/config-resolver" "3.222.0"
+    "@aws-sdk/credential-provider-node" "3.223.0"
+    "@aws-sdk/eventstream-serde-browser" "3.222.0"
+    "@aws-sdk/eventstream-serde-config-resolver" "3.222.0"
+    "@aws-sdk/eventstream-serde-node" "3.222.0"
+    "@aws-sdk/fetch-http-handler" "3.222.0"
+    "@aws-sdk/hash-blob-browser" "3.222.0"
+    "@aws-sdk/hash-node" "3.222.0"
+    "@aws-sdk/hash-stream-node" "3.222.0"
+    "@aws-sdk/invalid-dependency" "3.222.0"
+    "@aws-sdk/md5-js" "3.222.0"
+    "@aws-sdk/middleware-bucket-endpoint" "3.222.0"
+    "@aws-sdk/middleware-content-length" "3.222.0"
+    "@aws-sdk/middleware-endpoint" "3.222.0"
+    "@aws-sdk/middleware-expect-continue" "3.222.0"
+    "@aws-sdk/middleware-flexible-checksums" "3.222.0"
+    "@aws-sdk/middleware-host-header" "3.222.0"
+    "@aws-sdk/middleware-location-constraint" "3.222.0"
+    "@aws-sdk/middleware-logger" "3.222.0"
+    "@aws-sdk/middleware-recursion-detection" "3.222.0"
+    "@aws-sdk/middleware-retry" "3.222.0"
+    "@aws-sdk/middleware-sdk-s3" "3.222.0"
+    "@aws-sdk/middleware-serde" "3.222.0"
+    "@aws-sdk/middleware-signing" "3.222.0"
+    "@aws-sdk/middleware-ssec" "3.222.0"
+    "@aws-sdk/middleware-stack" "3.222.0"
+    "@aws-sdk/middleware-user-agent" "3.222.0"
+    "@aws-sdk/node-config-provider" "3.222.0"
+    "@aws-sdk/node-http-handler" "3.222.0"
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/signature-v4-multi-region" "3.222.0"
+    "@aws-sdk/smithy-client" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/url-parser" "3.222.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.222.0"
+    "@aws-sdk/util-defaults-mode-node" "3.222.0"
+    "@aws-sdk/util-endpoints" "3.222.0"
+    "@aws-sdk/util-stream-browser" "3.222.0"
+    "@aws-sdk/util-stream-node" "3.222.0"
+    "@aws-sdk/util-user-agent-browser" "3.222.0"
+    "@aws-sdk/util-user-agent-node" "3.222.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    "@aws-sdk/util-waiter" "3.222.0"
+    "@aws-sdk/xml-builder" "3.201.0"
+    fast-xml-parser "4.0.11"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sso-oidc@3.223.0":
+  version "3.223.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.223.0.tgz#6913bae1ed06d58e82af9ecb837c9cab88189590"
+  integrity sha512-MeXm6expqpBwwN5GWm8QedAxWGv1jpdxae5oSqsrfRSHFVcHVxWWQzx9/GMBpKqGLtXVmisex2vckBQa1MhybQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.222.0"
+    "@aws-sdk/fetch-http-handler" "3.222.0"
+    "@aws-sdk/hash-node" "3.222.0"
+    "@aws-sdk/invalid-dependency" "3.222.0"
+    "@aws-sdk/middleware-content-length" "3.222.0"
+    "@aws-sdk/middleware-endpoint" "3.222.0"
+    "@aws-sdk/middleware-host-header" "3.222.0"
+    "@aws-sdk/middleware-logger" "3.222.0"
+    "@aws-sdk/middleware-recursion-detection" "3.222.0"
+    "@aws-sdk/middleware-retry" "3.222.0"
+    "@aws-sdk/middleware-serde" "3.222.0"
+    "@aws-sdk/middleware-stack" "3.222.0"
+    "@aws-sdk/middleware-user-agent" "3.222.0"
+    "@aws-sdk/node-config-provider" "3.222.0"
+    "@aws-sdk/node-http-handler" "3.222.0"
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/smithy-client" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/url-parser" "3.222.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.222.0"
+    "@aws-sdk/util-defaults-mode-node" "3.222.0"
+    "@aws-sdk/util-endpoints" "3.222.0"
+    "@aws-sdk/util-user-agent-browser" "3.222.0"
+    "@aws-sdk/util-user-agent-node" "3.222.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sso@3.223.0":
+  version "3.223.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.223.0.tgz#7670d3e6626a328ecf7bbcebdbd51f2ea6e18b69"
+  integrity sha512-1gVmZ7XypZEWUeKnvjS/cZSL/cM1riOGrhp+dr+np58ZT5zSrpWAAeKE5+ftzC/vn770vnD5piLGdAZwg/Jf1g==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.222.0"
+    "@aws-sdk/fetch-http-handler" "3.222.0"
+    "@aws-sdk/hash-node" "3.222.0"
+    "@aws-sdk/invalid-dependency" "3.222.0"
+    "@aws-sdk/middleware-content-length" "3.222.0"
+    "@aws-sdk/middleware-endpoint" "3.222.0"
+    "@aws-sdk/middleware-host-header" "3.222.0"
+    "@aws-sdk/middleware-logger" "3.222.0"
+    "@aws-sdk/middleware-recursion-detection" "3.222.0"
+    "@aws-sdk/middleware-retry" "3.222.0"
+    "@aws-sdk/middleware-serde" "3.222.0"
+    "@aws-sdk/middleware-stack" "3.222.0"
+    "@aws-sdk/middleware-user-agent" "3.222.0"
+    "@aws-sdk/node-config-provider" "3.222.0"
+    "@aws-sdk/node-http-handler" "3.222.0"
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/smithy-client" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/url-parser" "3.222.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.222.0"
+    "@aws-sdk/util-defaults-mode-node" "3.222.0"
+    "@aws-sdk/util-endpoints" "3.222.0"
+    "@aws-sdk/util-user-agent-browser" "3.222.0"
+    "@aws-sdk/util-user-agent-node" "3.222.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sts@3.223.0":
+  version "3.223.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.223.0.tgz#19f6abb20d3aad8d3404fb4683b02e001e9067f0"
+  integrity sha512-RYGx6SOT38MfX4Dm8lyEwZ/bEqhl3TZyGFqtFHGTEEgyqPkuqiZPfSSWNmsaf6HAVYKObp7kJUX6w8EeEw332w==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.222.0"
+    "@aws-sdk/credential-provider-node" "3.223.0"
+    "@aws-sdk/fetch-http-handler" "3.222.0"
+    "@aws-sdk/hash-node" "3.222.0"
+    "@aws-sdk/invalid-dependency" "3.222.0"
+    "@aws-sdk/middleware-content-length" "3.222.0"
+    "@aws-sdk/middleware-endpoint" "3.222.0"
+    "@aws-sdk/middleware-host-header" "3.222.0"
+    "@aws-sdk/middleware-logger" "3.222.0"
+    "@aws-sdk/middleware-recursion-detection" "3.222.0"
+    "@aws-sdk/middleware-retry" "3.222.0"
+    "@aws-sdk/middleware-sdk-sts" "3.222.0"
+    "@aws-sdk/middleware-serde" "3.222.0"
+    "@aws-sdk/middleware-signing" "3.222.0"
+    "@aws-sdk/middleware-stack" "3.222.0"
+    "@aws-sdk/middleware-user-agent" "3.222.0"
+    "@aws-sdk/node-config-provider" "3.222.0"
+    "@aws-sdk/node-http-handler" "3.222.0"
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/smithy-client" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/url-parser" "3.222.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.222.0"
+    "@aws-sdk/util-defaults-mode-node" "3.222.0"
+    "@aws-sdk/util-endpoints" "3.222.0"
+    "@aws-sdk/util-user-agent-browser" "3.222.0"
+    "@aws-sdk/util-user-agent-node" "3.222.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    fast-xml-parser "4.0.11"
+    tslib "^2.3.1"
+
+"@aws-sdk/config-resolver@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.222.0.tgz#60a7a24659d121ce7d035a88fa541aac9851cd02"
+  integrity sha512-rG/Yh0R+GQe86ofEb24QAjQ19tHb4HMCyCuMZUZCsIdgNmUfcaH21Ug5s7pJrAfEy/F2gwxs+VfBeXKjT0MqSQ==
+  dependencies:
+    "@aws-sdk/signature-v4" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-config-provider" "3.208.0"
+    "@aws-sdk/util-middleware" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-env@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.222.0.tgz#1398c2818ef107a7f08ded3dd52233b98ef6f5e1"
+  integrity sha512-xV6cmJ9zMi8nWySqBv1ze/EFlzXEfazu3i/T/5MpOufPvuGpXTQ3/PDEbC6mKBtvomoQ0fonc/cZrix7YcJV0Q==
+  dependencies:
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-imds@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.222.0.tgz#a4d31b5d59b9e7cb443cdd094ed69712d249a2d9"
+  integrity sha512-n090ouw5AFhb0EfzRElUTmqCNOQ1zjlxau30oVM7+qKtXH85hEGMQOoRQAl9ch/pXcbjKLh1mbUhmonR97/Kvw==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.222.0"
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/url-parser" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-ini@3.223.0":
+  version "3.223.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.223.0.tgz#aa320e3ca387d810cd774c5462d65727236a7cea"
+  integrity sha512-+jB0XIqAw7Cni1uqPV6SMQl7FlpUVELdHVnR+DYL3WOV4MJ4amTu9MAXrpvbEXbK3+7eFQ2/tDe+7i8qGXZFTw==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.222.0"
+    "@aws-sdk/credential-provider-imds" "3.222.0"
+    "@aws-sdk/credential-provider-sso" "3.223.0"
+    "@aws-sdk/credential-provider-web-identity" "3.222.0"
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/shared-ini-file-loader" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-node@3.223.0":
+  version "3.223.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.223.0.tgz#7b1957b05cf6ddf97f01c6fdf8ab7afce07edc1d"
+  integrity sha512-mvY96yX4xQ9/Aujr0HqMXhdToiEKg7fFUoN+NgV3yB/hj2q1Ry3j8WbiIfAcBvFLjNwHT7ae/8nVRHYYlNeXFw==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.222.0"
+    "@aws-sdk/credential-provider-imds" "3.222.0"
+    "@aws-sdk/credential-provider-ini" "3.223.0"
+    "@aws-sdk/credential-provider-process" "3.222.0"
+    "@aws-sdk/credential-provider-sso" "3.223.0"
+    "@aws-sdk/credential-provider-web-identity" "3.222.0"
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/shared-ini-file-loader" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-process@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.222.0.tgz#cda2c37323cf451cb0157a08ce1644be2e7632bf"
+  integrity sha512-IgEk8Tne1b2v2k/wVjuddKi+HEAFJWUoEcvLCnYRdlVX5l+Nnatw8vGYb+gTi9X7nKNqEGfMbifKCFoePKjC0Q==
+  dependencies:
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/shared-ini-file-loader" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-sso@3.223.0":
+  version "3.223.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.223.0.tgz#7c5585e2ada71f902421a073b14c0e0ef46b5ffe"
+  integrity sha512-sRxH6fhLYME+EIiHRqIzkUgPaAvc5+dV8+09jEZ1yBjum9AQycipXrbbDRNLXWJZJZTA/BsHfUpAScFOjyZf7A==
+  dependencies:
+    "@aws-sdk/client-sso" "3.223.0"
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/shared-ini-file-loader" "3.222.0"
+    "@aws-sdk/token-providers" "3.223.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-web-identity@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.222.0.tgz#3af44d133c9976320aebf0a52b1ddf467798aa59"
+  integrity sha512-dImqTEWt38nVcDe/wQqHWJ+R2zyNqVKwejfslgbH2YilUnDU43xq2KJhNe4s+YhCB6tHOTkbNnpZo7vPV5Zxog==
+  dependencies:
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-codec@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-codec/-/eventstream-codec-3.222.0.tgz#ae57b2877eccf24f6335ce65fbc6a14c7a69e14c"
+  integrity sha512-sxLpo3NYrvj8CnTkpLsb2uXvUU8jnAG5q22HIBxBrpeFzgvUA9uIfPD7yPZhe4+/C7v+ER19ysXetKjiAOrQMA==
+  dependencies:
+    "@aws-crypto/crc32" "2.0.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-hex-encoding" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-browser@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.222.0.tgz#36630955cf9f0b076ebaed57d87fb04f2d0e3445"
+  integrity sha512-owwgmkpuLM7UtNPRZjvCOp5fo6MKY8avygQA0VMsbQSCq1DJFpmDsk7yTRB+n7jQuoDGn8uVxER3S0oS/Y/xVQ==
+  dependencies:
+    "@aws-sdk/eventstream-serde-universal" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-config-resolver@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.222.0.tgz#c480fd9178710ff257f84eae88b7360b394221e5"
+  integrity sha512-zb8vMSbBEjUrHKpA2bZdAqfYp8oCsWgeBPOt0XJx+y6lzy67zyADs97Grl+lyZAoswao/zc2sxgm9yqcMDt7lQ==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-node@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.222.0.tgz#fb2452fe24f6df4426a2c2a42b94bf25af8a1406"
+  integrity sha512-rfDrTxcsYL0ZKc5MnoqbDTa0oQFiK7qTJOnQ7sASooexqoKTn3wVq68J7TZddbImmH/ENpkU+O0hcGuiwE9Ucg==
+  dependencies:
+    "@aws-sdk/eventstream-serde-universal" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-universal@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.222.0.tgz#acae53e01d81b1f3f75874ab003cc54fb25ec4a8"
+  integrity sha512-+/Fc7+ZPuD6SwphYcuLJ/GU0RmVzG/M0dUYs1JL/JQJ8dkJ0AlH1fH3L5Fhm2RO/ACkE28kXAuyZ40TLeRLRNA==
+  dependencies:
+    "@aws-sdk/eventstream-codec" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/fetch-http-handler@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.222.0.tgz#84af5e3f6f8e2468d935cd11f53413f979c650dd"
+  integrity sha512-0PWnOp47mNfwBFEZhuBpz5A+66jbvb2ySidnM5vWHRxu5yN7rCJEdEMSJKDzR6nH3GLZ9dHoOxTzQy21NoDTtA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/querystring-builder" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-blob-browser@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.222.0.tgz#92d44e2234700ebd09b05a923a8a836665bef658"
+  integrity sha512-Z6y3JZPNp+os9vZdvsNkM6mIjDzeZNr9MYkQslANhGZ9WgQrzuI7xZN6XAyR83OGRCrDCorZdX+nnl5mzY1VwQ==
+  dependencies:
+    "@aws-sdk/chunked-blob-reader" "3.188.0"
+    "@aws-sdk/chunked-blob-reader-native" "3.208.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-node@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-3.222.0.tgz#ebe88b774230cb4f09bdb913c8759af29f79b5bd"
+  integrity sha512-Fw0acblG0LQT9tfD2/4j98QHNq+Crotig/M1/zPDcVoGb8OBHd2442zpeA0fYYjGnGGhy9psRHdJrjZGj1vDUw==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-stream-node@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-stream-node/-/hash-stream-node-3.222.0.tgz#da5b2012a2a9cbc3c8a8c48a9ee85a9943dd9b8f"
+  integrity sha512-PO/N0PsgJjRiH9WKSOnGjDP9tWNjwSvUezicT8ItWgkk7npd278MAe7G692TLACgf6sJr2jGQbs6xzZHq0/3Zg==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/invalid-dependency@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/invalid-dependency/-/invalid-dependency-3.222.0.tgz#ae81e031c09333f0ce13de7b29f04b285b8b725e"
+  integrity sha512-tWJWWTcL7DrhFiDmPBvLaw2lopHJMsF4Uj52yIQJskwd2IeBOxjl30zLo/oidmk73IFUB7TCObc85zJrtt/KcQ==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/is-array-buffer@3.201.0":
+  version "3.201.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz#06e557adc284fac2f26071c2944ae01f61b95854"
+  integrity sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/md5-js@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/md5-js/-/md5-js-3.222.0.tgz#61999d6776667cdcb3af0ca898566e290fa6455d"
+  integrity sha512-LI44dy+ECCL+vsIYJ/Ot4rNOl3Vpa4Nv8zxireKcQGmn547Cb6i3n/bEi/DkcfgHv6R84qOtOXsxt/ILuWNQ/g==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    "@aws-sdk/util-utf8-node" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-bucket-endpoint@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.222.0.tgz#a4312025b90a3f98d7ac4ea32b57a91773e9b01d"
+  integrity sha512-TP4mjEWsQ/JsACAFDUlltl/0sAe5dxqdhBDAPO6LHRHvROz2oYVjZwvcaK4F9x8QLWh09H0Sw501SndFK2+o3w==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-arn-parser" "3.208.0"
+    "@aws-sdk/util-config-provider" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-content-length@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-3.222.0.tgz#0c074d3aaf106cc69056946ab38bf913c522c6c3"
+  integrity sha512-Wlah+nrPhcq5qcwHiK1ymVRAvcKjV2py2RXhJsNZWgYwphdt5RHaZHPDKoodI27alrDJVyBBQWGzIm/Ag1bypQ==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-endpoint@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.222.0.tgz#7494bde024f05d88810408b41f51a87c91b626c1"
+  integrity sha512-e1bM+CvuUWmBdydQpV5sF8cxZrXQ++0G5s1M7pLimKdWXQvCQ1ZEwA3LLi2IWomXmS9a3BaH3iKAf87RTWjIXw==
+  dependencies:
+    "@aws-sdk/middleware-serde" "3.222.0"
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/signature-v4" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/url-parser" "3.222.0"
+    "@aws-sdk/util-config-provider" "3.208.0"
+    "@aws-sdk/util-middleware" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-expect-continue@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.222.0.tgz#a4764898c72f58d2968ca79ae063ca800e01773f"
+  integrity sha512-/nTCLXrau8jEyehsD7QM49gJQ6kmzQGw7plPDJzdFakfAwb2b/jLJ/Hj/ZSaaLWWEXAtZBiPzVXUJltPDoXv5g==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-flexible-checksums@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.222.0.tgz#605d60970027cc4374feaac3d4dcd4362e85b4c7"
+  integrity sha512-P900+KLMUg0eOf75FK/wH/Gjz3rkNtB6iBfAG2Xg4DY5+78qh40deG0y0ZvtkHQP8YOqjLF3QMbEA90YXo4x9Q==
+  dependencies:
+    "@aws-crypto/crc32" "2.0.0"
+    "@aws-crypto/crc32c" "2.0.0"
+    "@aws-sdk/is-array-buffer" "3.201.0"
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-host-header@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.222.0.tgz#9ab9f70cbc4883a827ea4382d4c9258f77ca9275"
+  integrity sha512-R4STwHkWgdxMRqOy6riYfXepsQURR5YhK6psPFZHkBYByIRc9JxJdLA0qZcfLRriQIAGmqEO2WWsqRmr8nkbBw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-location-constraint@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.222.0.tgz#2578b3cba6735b245d90bf013fa9eb5862cf7a11"
+  integrity sha512-srrAkOHuvpXeaMG9a6kvfYrhzFFX/plBaZATy8iW6ethgvG1qdPeFj4ZVS9Eisx+13NbGFtydc1WkBZfx2nUWg==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-logger@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.222.0.tgz#73e1fe235f26f733d1218c1b05dba8db58b4241a"
+  integrity sha512-eAxGCcNXl1APMOFbkUaAC6pNBPUbajyGqsDf6GLdlrYHrMVAtJdYd988ov6C52h7k6iDZ+OPHwv8dwUz+PRfpw==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-recursion-detection@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.222.0.tgz#838ef2113df278cb705456cd9d0fd682e987e11f"
+  integrity sha512-4JRVs7y5JDXXjc5fkz0FCZJt/0HTP2vh3QyZsWRbCYesw2cWVqQlp/fUXp8w5KGqm5nYkTF4e5SQ7Ca8powJNA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-retry@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.222.0.tgz#bd29d7c858d42985716d1077f73d747f30011f59"
+  integrity sha512-8FZpGuJDtntjXZ/mfJ9EdP5mYiUunQHEmk6OERk3h4XW3D/e97denwDAcBBIK8iYYGic5PoWF4KgTFJWs1YOcw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/service-error-classification" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-middleware" "3.222.0"
+    tslib "^2.3.1"
+    uuid "^8.3.2"
+
+"@aws-sdk/middleware-sdk-s3@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.222.0.tgz#15e2afe2dde591c19a17a3b48cc81f6dad130b00"
+  integrity sha512-GCgbzWy3Dn9+dz/ZZjS5OiJ+feighHfMt461r1zjHNUXnb2tEf5kU+P80d3WqG8er4RRQg+Ao49SatOKgPcrlA==
+  dependencies:
+    "@aws-sdk/middleware-bucket-endpoint" "3.222.0"
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-arn-parser" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-sdk-sts@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.222.0.tgz#c61e6f553b8517e9a1afdd92b03b1683d185af7c"
+  integrity sha512-YbL4lTBFgqyL2Ob+dMyw/UNd5K9IOnZHHxjpwWlYKMrfT+pp2bvrr7XUbRHnxSoDsOg9bf6IyTSRVnVxP4psJg==
+  dependencies:
+    "@aws-sdk/middleware-signing" "3.222.0"
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/signature-v4" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-serde@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-3.222.0.tgz#b4decb3bbb8e373d393e0c607b5af175cbfc2396"
+  integrity sha512-UoeLbgCJB07dX8tRByR0KzZaOwCoIyXj/SfFTuOhBUjkpKwqFCam/hofDlK3FR6kvl+xiURv57W/FtKV/9TDHg==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-signing@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.222.0.tgz#8bb645b4943bc13ec0517a7cb019a1d0b0a6eacb"
+  integrity sha512-MwMw2Lz7SBOniAc0slWXt65ocqL+E956bdW+LOvBin6OgkVWaLRbWI9nOzA6B2d8b65fCGEc+N15i0UdrEf+MQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/signature-v4" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-middleware" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-ssec@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-ssec/-/middleware-ssec-3.222.0.tgz#3e1fe2a4f675a15e69c5bb0c3e4684c430baeca4"
+  integrity sha512-WThCx/+UG4gIyqx0G3QKD1RM71+adh9Jv3Sh/KiS07Jjm+pb71wW+RRzBuNyhdjwB3aoKC/YKW8eFQg6M7eaQg==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-stack@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-3.222.0.tgz#c55b4f8408e6b111f25ca3a5ce24118e54968dfd"
+  integrity sha512-ASKbstAKbOBUZhFhst6/NCr11x94BDBiQn2zDs2Lvjo89n2efMeb4wEr17VCMZVeKI6ojtPFa1ZVLsH8AOn4Yw==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-user-agent@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.222.0.tgz#3a891abf3eab3db8dc7df7f9ca36d70d240a2d44"
+  integrity sha512-fjdxCRIAhOTsI9OcEKwJp4lhsvyCSXoeYV49mO/bdG6pFyFRm3Jezx7TNVNeLTGuMHTTTvRrCTF8sgE5t17Pzw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-config-provider@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.222.0.tgz#1eae0219266c656006c902b730480727a47f39c5"
+  integrity sha512-hrbw90LlVa4xJJc4WiyAfaPMY/sJubSeTwuxTChLsFOavr6hSMCwLASrWmOiKRIj5hKdSfEA87n/q+DnKHlA8A==
+  dependencies:
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/shared-ini-file-loader" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-http-handler@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-3.222.0.tgz#920fc5bacfcc5e0b901d425e4f9779228a93ebaa"
+  integrity sha512-k3WqxUgZzGbiCQt1HyzDGlRzq8muGIOWZs9T3HtCa5LtACvl0qlNmiwCc+C/o7GRLyC9FuWkP3lOW6MiAFQUcA==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.222.0"
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/querystring-builder" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/property-provider@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-3.222.0.tgz#fa889a31277cf3a91bd3e8ac4f618db4fdb122ed"
+  integrity sha512-rEqAgQ7itmB7GB+WWLgyT7/YWJkjEBCfggxycccChWAeqg+gjpstIiGX2BjP2K/wnzwE0D91JsozSXcQIDOtNQ==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/protocol-http@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-3.222.0.tgz#c5f82957d304bb2eb31a117c9a5d86a7772b4f86"
+  integrity sha512-Zj+ytEgrOagCE7yczjdDan7W+1a0OL5DPAx69Z00NxGoBI2h0GRZD28dRYb3Pzs5/Ft4KbCedH/RUnyaYjaZxw==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-builder@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-3.222.0.tgz#6e0c93db85ecfa3038258511f47c67e6978218b2"
+  integrity sha512-qrNUGDyDp9yVQMnBbz1T5YBQkA/u6D5o0PPzSwfZ9azdAcBLjHOEfsBrKhxP+K92L/nilbnmY89KrjMR8+BNtw==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-uri-escape" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-parser@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-3.222.0.tgz#2b53b529d8c3ce347ac1900bcf16e728fe4e28b7"
+  integrity sha512-3KfkCA/753PlF5QqhGuQ7u+NOgLyiBFeV8R8ut/pfBmG8fF6l3RKrkbcu+87QpqXntRzG+RLHDqS7ryT3B2ICg==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/service-error-classification@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.222.0.tgz#6ffeea922f17a0b6e91e8bda9f74f1a04385f499"
+  integrity sha512-Dn/WGtm+v5nney0CaYZjdOtJmdEuI8EQiQ5J3eQ3G0jjT6mr1/tCajsNpq3ZqHXiwLtydwaVvsL3AKXn+oxFVA==
+
+"@aws-sdk/shared-ini-file-loader@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.222.0.tgz#2ddf077e3b81639cbb1bf550122946bf86d26230"
+  integrity sha512-2dowzMXjvIf5gwX5gNCwpv/TzAbbXxrId3zYJgPdEtApsa7NxyFs5MfnHt1zZI6P3YORGheRnNUK9RUYOPKHgA==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/signature-v4-multi-region@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.222.0.tgz#d4b4d9ab0cea9d9f38a3bc791aa3e2f67d0d977b"
+  integrity sha512-SF6Qi0KW69OzgLbA9q6AsZNFQCA+DI66SnAjW774sAE6aQyJmCbUsxETk37XodSymXzDOEDDC6QoY64HUoSoVw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.222.0"
+    "@aws-sdk/signature-v4" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-arn-parser" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/signature-v4@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-3.222.0.tgz#1c96d67d172eb68a89240eed834489d2ed79700b"
+  integrity sha512-2qQZuKqx56b2uN2rdjdKL6u0Cvk82uTGNtIuetmySY9xPEAljSBdriaxTqNqK9Gs3M4obG22alUK4a85uwqS3g==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.201.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-hex-encoding" "3.201.0"
+    "@aws-sdk/util-middleware" "3.222.0"
+    "@aws-sdk/util-uri-escape" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/smithy-client@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.222.0.tgz#c7dddbd82e9da4d3fc1416c98169593635873bd9"
+  integrity sha512-4dnU7TvwKxVuOWduvFGClYe0EgNov5Ke1ef7O1bdKaj5MmlH6wBDgGJM4NKREBFapC2dUXkoPtwsihtYBci1Bw==
+  dependencies:
+    "@aws-sdk/middleware-stack" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/token-providers@3.223.0":
+  version "3.223.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.223.0.tgz#fdde36cd3ad6639dd4258b146376dec9ccc531d0"
+  integrity sha512-ik6IYiZO9tTzYPJKzUob4U9faC9We6UtVZGynEGLMWSLETM+LefSHK0elEaJaCqx2F4NLodw+t9uvllR+8YUow==
+  dependencies:
+    "@aws-sdk/client-sso-oidc" "3.223.0"
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/shared-ini-file-loader" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/types@3.222.0", "@aws-sdk/types@^3.1.0", "@aws-sdk/types@^3.110.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.222.0.tgz#e61eb257f0ad2eaa65f7a72b9a2882f914fbcbb5"
+  integrity sha512-yXRYptInkfEFaOvWFxlRXsRh9jWOmQc1sZeKqjfx2UCtzNJ7ebedN0VfCz4SaDotcw9Q4JWuN66qhRMJjDx7/w==
+
+"@aws-sdk/url-parser@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser/-/url-parser-3.222.0.tgz#74118f3d824d2bb7415fe909c4db62aff5f42667"
+  integrity sha512-1+QbVdT/phYDb5JDQRJWoZeCujkXaI5m8z3bIiPxcRRY3NPuluDGrfX3kfnFen5s9QGByLvJxWKWZS+i+iUFRg==
+  dependencies:
+    "@aws-sdk/querystring-parser" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-arn-parser@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz#56b6ae4699c3140bb27dcede5146876fef04e823"
+  integrity sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-base64@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz#36b430e5396251f761590f7c2f0c5c12193f353c"
+  integrity sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-browser@3.188.0":
+  version "3.188.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz#e1d949318c10a621b38575a9ef01e39f9857ddb0"
+  integrity sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-node@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz#baabd1fa1206ff2bd4ce3785122d86eb3258dd20"
+  integrity sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-buffer-from@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz#285e86f6dc9030148a4147d65239e75cb254a1b0"
+  integrity sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-config-provider@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz#c485fd83fbac051337e5f6be60ea3f9fa61c0139"
+  integrity sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-browser@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.222.0.tgz#6b9e34903fa4bf1efb159c9531b0ea113baf2db0"
+  integrity sha512-+dGsp59lrEkDmK7OO5ecMYasrTGIKacFHjqZ6aqmbn1xtcUd/o3Qe7g5YSRXMGwtZ6xhvBD+NJLkEERI7U7cMw==
+  dependencies:
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-node@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.222.0.tgz#71fc2d52c9f564c689823f8cd337abde99d70406"
+  integrity sha512-W/duYMtmCCWdzHP+yscBB6yrARgAqWpFdxgBvMSlT8TjOTrh/F+aj4NPamiNMeUfqfMFGnboYfyWRr1avkcAGQ==
+  dependencies:
+    "@aws-sdk/config-resolver" "3.222.0"
+    "@aws-sdk/credential-provider-imds" "3.222.0"
+    "@aws-sdk/node-config-provider" "3.222.0"
+    "@aws-sdk/property-provider" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-endpoints@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.222.0.tgz#3deb963da8bec939dc2a08cb7f52b66900da28d4"
+  integrity sha512-qujJQv8lFysAr1lOlBTJhz7949NZyq5cj74Q9dR99AcAMXXeI9CQayPKH7477AnXRGOTMahZ3mV0HZ1bCJoNTw==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-hex-encoding@3.201.0":
+  version "3.201.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz#21d7ec319240ee68c33d938e71cb79830bea315d"
+  integrity sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz#0f598fc238a1256e4bcb64d01459f03a922dd4c3"
+  integrity sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-middleware@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-middleware/-/util-middleware-3.222.0.tgz#e23a5109081769762492890672b15ea54297bd0e"
+  integrity sha512-Y4BPtSa+6+qvg6OVW6RrdDx0OADfWa2Uxsxqdozpdnx2OQY0q+1diqsNgFMV+FIvdXqffE147KG7roG+/AfPeA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-stream-browser@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-stream-browser/-/util-stream-browser-3.222.0.tgz#96ea5269020dbd91edcc2be4382166670dbfb17e"
+  integrity sha512-GW9Y1/pLHS7WYHHdswcDd4vaM9mzxDwewcDVujCd/L9MRbG1nA/wfCL7hAAXT1AN2GbGfbfT+jjHQqzexpKBnA==
+  dependencies:
+    "@aws-sdk/fetch-http-handler" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-hex-encoding" "3.201.0"
+    "@aws-sdk/util-utf8-browser" "3.188.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-stream-node@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-stream-node/-/util-stream-node-3.222.0.tgz#7479188dff293b25d4eadfba38e03bfb95268bc5"
+  integrity sha512-iMwKG+RaGVAjzXDuzmMl63SnN6qVc+0VbbfaKW1eIK9Ihr5mko3GuYAFqKaECSQ+XdMNuMSVXzphveKw6t2zwg==
+  dependencies:
+    "@aws-sdk/node-http-handler" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-uri-escape@3.201.0":
+  version "3.201.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz#5e708d4cde001a4558ee616f889ceacfadd2ab03"
+  integrity sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-browser@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.222.0.tgz#a9f220475a11a705ae82eac10f3b422122c6ee4f"
+  integrity sha512-DREMeL0XHl4QIS2GVSHFwVH4mJZ+Dr04R3U8WfiMktXdA93j5tDMJpU3+PNaCZPeaqz2QNwrVSBWKwbwA357zQ==
+  dependencies:
+    "@aws-sdk/types" "3.222.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-node@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.222.0.tgz#235a5f415bf830f937bf50e04d1d26381e964f9d"
+  integrity sha512-BMRMrPXL/HS3dSha9vcABkoANluKjB0pH78bc659EY2WUj9wCZdbUNQpACiYx8bwm7xKSxugCkmPd6NLWXUURw==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-browser@3.188.0", "@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.188.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz#484762bd600401350e148277731d6744a4a92225"
+  integrity sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-node@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz#eba17de0f92f87b98481c2e2d0ceaa05c7994d67"
+  integrity sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-waiter@3.222.0":
+  version "3.222.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-waiter/-/util-waiter-3.222.0.tgz#19bdd77937b245ab319ed95a1cd751b59bf55982"
+  integrity sha512-/07RkfxvDncsMeQ+GhigPdiSRd2v/1FJoCV4a5e9XDI1ZSMvUKm36wFqw5Bzts+AUY8f4HOPpGI9ZQeNb7u27Q==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.222.0"
+    "@aws-sdk/types" "3.222.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/xml-builder@3.201.0":
+  version "3.201.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz#acf0869855460528114bec17f290b224fe19a3e2"
+  integrity sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==
+  dependencies:
+    tslib "^2.3.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -1264,11 +2230,14 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.50.0:
-  version "2.50.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.50.0.tgz#2b3a9ba4c1c4c56fd32e3e4f57eea8bf9fa3dbba"
-  integrity sha512-deDbZTI7oyu3rqUyqjwhP6tnUO8MD70lE98yR65xiYty4yXBpsWKbeH3s1wNLpLAWS3hWJYyMtjZ4ZfC35NtVg==
+aws-cdk-lib@2.53.0:
+  version "2.53.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.53.0.tgz#c36ecfb87ba4e7d1cdfe0c620161beda0ce4aa67"
+  integrity sha512-ADpJ9luJxzmOrP/GJ37nA1YtdNmsOsjE+NZnQOpB7YL0spUxZJGNVAselaFLSDZmIsC6d9mSnW81fj4SDP1gAw==
   dependencies:
+    "@aws-cdk/asset-awscli-v1" "^2.2.9"
+    "@aws-cdk/asset-kubectl-v20" "^2.1.1"
+    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.15"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"
@@ -1290,9 +2259,9 @@ aws-lambda@^1.0.7:
     watchpack "^2.0.0-beta.10"
 
 aws-sdk@^2.1266.0, aws-sdk@^2.814.0:
-  version "2.1266.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1266.0.tgz#38e7bb8ce4e4af16acd20b4ceea2832e82f60b68"
-  integrity sha512-UUj4TXP/V0rCbBmuIu7NLQyX4j2ZU81iEiM856eGvhWGha2M3LnKteA6JqKMjGx2weKRVaIcfkgLCyKIs3KEAg==
+  version "2.1267.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1267.0.tgz#8f45c7bc7efb89a757526d993c5f77a2e7208676"
+  integrity sha512-ANTtRay26WwNRbYs6eZYN71b3DURNfWaq3AD6BtVNa8fVvnSLn+NNINw2+vLRjDLPZXMAQVHm0qH/TmyBvtjRA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1375,6 +2344,11 @@ base64-js@^1.0.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 boxen@^7.0.0:
   version "7.0.0"
@@ -2550,9 +3524,9 @@ eslint-visitor-keys@^3.3.0:
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^8:
-  version "8.28.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.28.0.tgz#81a680732634677cc890134bcdd9fdfea8e63d6e"
-  integrity sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==
+  version "8.29.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.29.0.tgz#d74a88a20fb44d59c51851625bc4ee8d0ec43f87"
+  integrity sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==
   dependencies:
     "@eslint/eslintrc" "^1.3.3"
     "@humanwhocodes/config-array" "^0.11.6"
@@ -2713,10 +3687,17 @@ fast-memoize@^2.5.2:
   resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
   integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
 
+fast-xml-parser@4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz#42332a9aca544520631c8919e6ea871c0185a985"
+  integrity sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==
+  dependencies:
+    strnum "^1.0.5"
+
 fastq@^1.6.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
-  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.14.0.tgz#107f69d7295b11e0fccc264e1fc6389f623731ce"
+  integrity sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==
   dependencies:
     reusify "^1.0.4"
 
@@ -5345,9 +6326,9 @@ progress@^2.0.3:
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 projen@^0.65.43:
-  version "0.65.43"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.65.43.tgz#a0c831aa3bc73fa1dde4f918f7c8bacfe37b73df"
-  integrity sha512-VCPLUlgpWuALKb1s4znjZqYugWR33dUJ/T2f+wB2h3BX7e56aAm80lIandgM8T/X6kd9qaYo+3Li/xhawqXadA==
+  version "0.65.45"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.65.45.tgz#5a46fb8cd723a3f61acf619600583a863d966cff"
+  integrity sha512-5+ExHUZ/E7Se0T8BExfgdrZL1b8Ai1HJaSyIUsUaFd6Vwb3/6SiBYoYMcS4HRJv0Ad9EVxV0ysU6pWJGEzfDFg==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"
@@ -6106,6 +7087,11 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -6293,12 +7279,12 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1:
+tslib@^1.11.1, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.4.0:
+tslib@^2.3.1, tslib@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
@@ -6376,7 +7362,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.9.3:
+typescript@4.9.3:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
   integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==


### PR DESCRIPTION
fixes: #24 
Adds support for Image Optimization. I was unable to get the standalone optimization for some reason, but if someone can get that working that would be preferable over adding this feature.

- Supports images hosted on S3 or external images (don't forget to config domains in next.config.js)

Feedback appreciated.

TODO: Add documentation

Usage:
```
 const site = new NextjsSst(stack, 'Web', {
  app,
  ...
  imageOptimizationBucket: bucket, // Optional, if not provided, it will use the assets bucket, NOTE: each deployment will clear resources not in the `/public` folder
  ...
})
```

```
// Add trusted domains in next.config.js
images: {
    remotePatterns: [
      {
        protocol: 'https',
        hostname: '**.example.com',
      },
    ],
  },
```
Upload some images in the assets or the bucket you provided, eg: `/dogs/doge.png`. Or if you're using the default assets buckets, images in your nextjs app's `/public` will be uploaded there.

```
<Image src="/dogs/doge.png" width={1000} />
<Image src="/dogs/doge.png" width={100} />
```
Look at the image size and intrinsic dimensions to validate they have been resized.


MISC:
We may want to use this: https://github.com/aws-samples/image-optimization/blob/main/functions/image-processing/index.js.
Save the transformed images into S3 for future lookups. This is a trade off b/t storage vs compute... cost vs speed vs cache busting.
