### PR TITLE
fix: Forward all headers to SSR pages

### DIFF
--- a/assets/lambda@edge/LambdaOriginRequest.ts
+++ b/assets/lambda@edge/LambdaOriginRequest.ts
@@ -10,6 +10,11 @@ export const handler: CloudFrontRequestHandler = (event, _context, callback) => 
   const request = event.Records[0].cf.request;
   // console.log('request', JSON.stringify(request, null, 2));
 
+  // remove cookies from requests to S3
+  if (request.origin?.s3) {
+    request.headers.cookie = [];
+  }
+
   // get config (only for custom lambda HTTP origin)
   const originUrlHeader = getCustomHeaderValue(request, 'x-origin-url');
   if (!originUrlHeader) return callback(null, request);

--- a/assets/lambda@edge/LambdaOriginRequest.ts
+++ b/assets/lambda@edge/LambdaOriginRequest.ts
@@ -28,7 +28,7 @@ export const handler: CloudFrontRequestHandler = (event, _context, callback) => 
  * We have to use custom headers for passing configuration to the lambda@edge function.
  */
 function getCustomHeaderValue(request: CloudFrontRequest, headerName: string): string | undefined {
-  const originUrlHeader = request.origin?.custom?.customHeaders[headerName];
+  const originUrlHeader = request.origin?.custom?.customHeaders?.[headerName];
 
   if (!originUrlHeader || !originUrlHeader[0]) {
     if (request.origin?.custom) {

--- a/src/Nextjs.ts
+++ b/src/Nextjs.ts
@@ -450,13 +450,7 @@ export class Nextjs extends Construct {
     const fallbackOriginRequestPolicy = new cloudfront.OriginRequestPolicy(this, 'FallbackOriginRequestPolicy', {
       cookieBehavior: cloudfront.OriginRequestCookieBehavior.all(), // pretty much disables caching - maybe can be changed
       queryStringBehavior: cloudfront.OriginRequestQueryStringBehavior.all(),
-      // we cannot forward the host header to a lambda URL
-      headerBehavior: cloudfront.OriginRequestHeaderBehavior.allowList(
-        'Accept',
-        'Referer',
-        'User-Agent',
-        'Content-Type'
-      ),
+      headerBehavior: cloudfront.OriginRequestHeaderBehavior.all(),
       comment: 'Nextjs Fallback Origin Request Policy',
     });
 
@@ -485,7 +479,7 @@ export class Nextjs extends Construct {
         cachePolicy: lambdaCachePolicy,
         originRequestPolicy: fallbackOriginRequestPolicy,
 
-        // edgeLambdas: lambdaOriginEdgeFns,
+        edgeLambdas: lambdaOriginEdgeFns,
       },
 
       additionalBehaviors: {


### PR DESCRIPTION
Fixes a bug where we weren't forwarding all headers to the default behavior. Basically not all headers were available to `getServerSideProps` functions. Now they should be. 

This didn't work before because the Host header would be wrong for the lambda function URL origin but we now have a Lambda@Edge function to fix up the Host header.