### PR TITLE
fix: update quickstart doc to address non monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ new Nextjs(this, 'Web', {
 });
 ```
 
-If your Nextjs App is not at the root, you will [need](https://nextjs.org/docs/advanced-features/output-file-tracing#caveats) to point your `next.config.js` at the project root:
+If your NextJS app is not at the root, you will [need](https://nextjs.org/docs/advanced-features/output-file-tracing#caveats) to point your `next.config.js` at the project root:
 
 ```ts
 const path = require("path");

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ new Nextjs(this, 'Web', {
 });
 ```
 
-If using a **monorepo**, you will [need](https://nextjs.org/docs/advanced-features/output-file-tracing#caveats) to point your `next.config.js` at the project root:
+If your Nextjs App is not at the root, you will [need](https://nextjs.org/docs/advanced-features/output-file-tracing#caveats) to point your `next.config.js` at the project root:
 
 ```ts
 const path = require("path");


### PR DESCRIPTION
This problem and configuration is not exclusive to monorepos, which may lead to confusion and error for users who aren't using monorepos - as they will skip this important step.