### PR TITLE
fix: prevent crash if nextjs app does not contain public folder

### DIFF
--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -148,6 +148,7 @@ export class NextjsBuild extends Construct {
 
   readPublicFileList() {
     const publicDir = this._getNextPublicDir();
+    if (!fs.existsSync(publicDir)) return [];
     return listDirectory(publicDir).map((file) => path.join('/', path.relative(publicDir, file)));
   }
 


### PR DESCRIPTION
Fixes #34 

There may be some usecase/scenario where there are no public folders (someone in discord had this setup)

Wasn't sure if we should add this validation in the `listDirectory` function but it's only being used in 2 places right now.