### PR TITLE
DO NOT MERGE feat: automatically determine tracing root

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,6 @@ new Nextjs(this, 'Web', {
 });
 ```
 
-If your NextJS app is not at the root, you will [need](https://nextjs.org/docs/advanced-features/output-file-tracing#caveats) to point your `next.config.js` at the project root:
-
-```ts
-const path = require("path");
-
-const nextConfig = {
-  ...
-  experimental: {
-    outputFileTracingRoot: path.join(__dirname, '..'), // if your nextjs app lives one level deep
-  },
-}
-
-module.exports = nextConfig;
-```
-
 ## Documentation
 
 Available on [Construct Hub](https://constructs.dev/packages/cdk-nextjs-standalone/).

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -13,6 +13,7 @@ const NEXTJS_STATIC_DIR = 'static';
 const NEXTJS_PUBLIC_DIR = 'public';
 const NEXTJS_BUILD_STANDALONE_DIR = 'standalone';
 const NEXTJS_BUILD_STANDALONE_ENV = 'NEXT_PRIVATE_STANDALONE';
+const NEXTJS_BUILD_OUTPUTTRACEROOT_ENV = 'NEXT_PRIVATE_OUTPUT_TRACE_ROOT ';
 
 export interface NextjsBuildProps extends NextjsBaseProps {}
 
@@ -108,6 +109,7 @@ export class NextjsBuild extends Construct {
     const buildEnv = {
       ...process.env,
       [NEXTJS_BUILD_STANDALONE_ENV]: 'true',
+      [NEXTJS_BUILD_OUTPUTTRACEROOT_ENV]: __dirname,
       ...getBuildCmdEnvironment(this.props.environment),
       ...(this.props.nodeEnv ? { NODE_ENV: this.props.nodeEnv } : {}),
     };


### PR DESCRIPTION
Since we're already requiring that the client to pass in "path", we can use that to determine the project root value.

Close and delete me if this isn't a good idea.