### PR TITLE
DNM feat: cache static pages

### DIFF
--- a/API.md
+++ b/API.md
@@ -467,6 +467,7 @@ Any object.
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneBuildDir">nextStandaloneBuildDir</a></code> | <code>string</code> | NextJS project inside of standalone build. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneDir">nextStandaloneDir</a></code> | <code>string</code> | Entire NextJS build output directory. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStaticDir">nextStaticDir</a></code> | <code>string</code> | Static files containing client-side code. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStaticPages">nextStaticPages</a></code> | <code>string</code> | Static Pages containing static pages. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.props">props</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps">NextjsBuildProps</a></code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | *No description.* |
 
@@ -547,6 +548,18 @@ public readonly nextStaticDir: string;
 - *Type:* string
 
 Static files containing client-side code.
+
+---
+
+##### `nextStaticPages`<sup>Required</sup> <a name="nextStaticPages" id="cdk-nextjs-standalone.NextjsBuild.property.nextStaticPages"></a>
+
+```typescript
+public readonly nextStaticPages: string;
+```
+
+- *Type:* string
+
+Static Pages containing static pages.
 
 ---
 

--- a/src/NextjsAssetsDeployment.ts
+++ b/src/NextjsAssetsDeployment.ts
@@ -136,6 +136,19 @@ export class NextJsAssetsDeployment extends Construct {
       });
     }
 
+    // copy static pages to root
+    if (!this.props.isPlaceholder) {
+      const staticPagesPath = this.props.nextBuild.nextStaticPages;
+      const pages = fs.readdirSync(staticPagesPath);
+      // NOTE: pages that have .html extension are static
+      const staticPages = pages.filter((page) => page.endsWith('.html'));
+      for (const p of staticPages) {
+        // NOTE: .html is dropped b/c that is the raw path of the url
+        const trimmedPage = p.replace('.html', '');
+        fs.moveSync(path.join(staticPagesPath, p), path.join(archiveDir, trimmedPage));
+      }
+    }
+
     return archiveDir;
   }
 

--- a/src/NextjsAssetsDeployment.ts
+++ b/src/NextjsAssetsDeployment.ts
@@ -144,8 +144,7 @@ export class NextJsAssetsDeployment extends Construct {
       const staticPages = pages.filter((page) => page.endsWith('.html'));
       for (const p of staticPages) {
         // NOTE: .html is dropped b/c that is the raw path of the url
-        const trimmedPage = p.replace('.html', '');
-        fs.moveSync(path.join(staticPagesPath, p), path.join(archiveDir, trimmedPage));
+        fs.moveSync(path.join(staticPagesPath, p), path.join(archiveDir, p));
       }
     }
 
@@ -188,7 +187,6 @@ export class NextJsAssetsDeployment extends Construct {
     }
     listDirectory(staticDir).forEach((file) => {
       const relativePath = path.relative(staticDir, file);
-
       // skip bogus system files
       if (relativePath.endsWith('.DS_Store')) return;
 

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -10,6 +10,7 @@ import { CompressionLevel, NextjsBaseProps } from './NextjsBase';
 
 const NEXTJS_BUILD_DIR = '.next';
 const NEXTJS_STATIC_DIR = 'static';
+const NEXTJS_STATIC_PAGES_DIR = 'server/pages';
 const NEXTJS_PUBLIC_DIR = 'public';
 const NEXTJS_BUILD_STANDALONE_DIR = 'standalone';
 const NEXTJS_BUILD_STANDALONE_ENV = 'NEXT_PRIVATE_STANDALONE';
@@ -43,6 +44,11 @@ export class NextjsBuild extends Construct {
    * Static files containing client-side code.
    */
   public nextStaticDir: string;
+
+  /**
+   * Static Pages containing static pages.
+   */
+  public nextStaticPages: string;
   /**
    * Public static files.
    * E.g. robots.txt, favicon.ico, etc.
@@ -79,6 +85,7 @@ export class NextjsBuild extends Construct {
     this.nextStandaloneBuildDir = this._getNextStandaloneBuildDir();
     this.nextPublicDir = this._getNextPublicDir();
     this.nextStaticDir = this._getNextStaticDir();
+    this.nextStaticPages = this._getNextStaticPages();
 
     this.buildPath = this.nextStandaloneBuildDir;
   }
@@ -188,6 +195,9 @@ export class NextjsBuild extends Construct {
   // contains static files
   private _getNextStaticDir() {
     return path.join(this._getNextBuildDir(), NEXTJS_STATIC_DIR);
+  }
+  private _getNextStaticPages() {
+    return path.join(this._getNextBuildDir(), NEXTJS_STATIC_PAGES_DIR);
   }
   private _getNextPublicDir() {
     return path.join(this._getNextDir(), NEXTJS_PUBLIC_DIR);

--- a/src/NextjsS3EnvRewriter.ts
+++ b/src/NextjsS3EnvRewriter.ts
@@ -72,7 +72,7 @@ export class NextjsS3EnvRewriter extends Construct {
       code: lambda.Code.fromAsset(handlerDir),
       initialPolicy: [
         new iam.PolicyStatement({
-          actions: ['s3:GetObject', 's3:PutObject'],
+          actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
           resources: [s3Bucket.arnForObjects('*')],
         }),
         ...(cloudfrontDistributionId


### PR DESCRIPTION
fixes: #27 
This copies the static pages into the asset bucket so requests to `/staticPage` skips the lambda.

TODO: 
- Test that updating static pages will be updated on deployment.
GOTCHAS:
- Static pages won't go through middleware when refreshed... but I think this is correct behavior.