### PR TITLE
chore: Make supported NextJs version more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## What is this?
 
-A CDK construct to deploy a NextJS 12.3.0+ app using AWS CDK.
+A CDK construct to deploy a NextJS app using AWS CDK.
+Supported NextJs versions: 12.3.0+ (includes 13.0.0+)
 
 Uses the [standalone output](https://nextjs.org/docs/advanced-features/output-file-tracing) build mode.
 


### PR DESCRIPTION
Improves documentation. Make supported NextJs versions more clear. Earlier the text was **12.3.0+** , which could've been misinterpreted as Next v12 only ( min 12.3.0 ). The change provides the context that Next 13 is also supported. 