### PR TITLE
chore: move server ahead of s3 group

### DIFF
--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -334,8 +334,8 @@ export class NextjsDistribution extends Construct {
     ];
 
     // default handler for requests that don't match any other path:
-    //   - try S3 first
-    //   - if 403, fall back to lambda handler (mostly for /)
+    //   - try lambda handler first (/some-page, etc...)
+    //   - if 403, fall back to S3
     //   - if 404, fall back to lambda handler
     const fallbackOriginGroup = new origins.OriginGroup({
       primaryOrigin: serverFunctionOrigin,

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -338,8 +338,8 @@ export class NextjsDistribution extends Construct {
     //   - if 403, fall back to lambda handler (mostly for /)
     //   - if 404, fall back to lambda handler
     const fallbackOriginGroup = new origins.OriginGroup({
-      primaryOrigin: s3Origin,
-      fallbackOrigin: serverFunctionOrigin,
+      primaryOrigin: serverFunctionOrigin,
+      fallbackOrigin: s3Origin,
       fallbackStatusCodes: [403, 404],
     });
 


### PR DESCRIPTION
Server response should have higher priority than S3 assets since most assets are cached at bucket level policy.