### PR TITLE
fix: Node16 runtime

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.53.0",
+      "version": "2.50.0",
       "type": "build"
     },
     {
@@ -184,7 +184,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.53.0",
+      "version": "^2.50.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -2,7 +2,7 @@ const { awscdk } = require('projen');
 const project = new awscdk.AwsCdkConstructLibrary({
   author: 'JetBridge',
   authorAddress: 'mischa@jetbridge.com',
-  cdkVersion: '2.53.0',
+  cdkVersion: '2.50.0',
   defaultReleaseBranch: 'main',
   name: 'cdk-nextjs-standalone',
   repositoryUrl: 'https://github.com/jetbridge/cdk-nextjs.git',

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.53.0",
+    "aws-cdk-lib": "2.50.0",
     "aws-sdk": "^2.1266.0",
     "constructs": "10.0.5",
     "eslint": "^8",
@@ -63,7 +63,7 @@
     "typescript": "4.9.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.53.0",
+    "aws-cdk-lib": "^2.50.0",
     "constructs": "^10.0.5"
   },
   "dependencies": {

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Duration } from 'aws-cdk-lib';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { FunctionOptions } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { IBucket } from 'aws-cdk-lib/aws-s3';

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -7,6 +7,7 @@ import { FunctionOptions } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
+import { LAMBDA_RUNTIME } from './constants';
 import { NextjsBaseProps } from './NextjsBase';
 import type { NextjsBuild } from './NextjsBuild';
 import { NextjsLayer } from './NextjsLayer';
@@ -40,8 +41,6 @@ export interface ImageOptimizationProps extends NextjsBaseProps {
   readonly nextBuild: NextjsBuild;
 }
 
-const RUNTIME = lambda.Runtime.NODEJS_18_X;
-
 /**
  * This lambda handles image optimization.
  */
@@ -69,7 +68,7 @@ export class ImageOptimizationLambda extends NodejsFunction {
 
     super(scope, id, {
       entry: imageOptHandlerPath,
-      runtime: RUNTIME,
+      runtime: LAMBDA_RUNTIME,
       bundling: {
         commandHooks: {
           beforeBundling(_: string, outputDir: string): string[] {

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -15,7 +15,7 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import * as fs from 'fs-extra';
 import { bundleFunction } from './BundleFunction';
-import { DEFAULT_STATIC_MAX_AGE } from './constants';
+import { DEFAULT_STATIC_MAX_AGE, LAMBDA_RUNTIME } from './constants';
 import { BaseSiteDomainProps, buildErrorResponsesForRedirectToIndex, NextjsBaseProps } from './NextjsBase';
 import { NextjsBuild } from './NextjsBuild';
 
@@ -520,7 +520,7 @@ export class NextjsDistribution extends Construct {
     });
 
     const fn = new cloudfront.experimental.EdgeFunction(this, 'DefaultOriginRequestEdgeFn', {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: LAMBDA_RUNTIME,
       // role,
       handler: 'LambdaOriginRequest.handler',
       code: lambda.Code.fromAsset(dirname(outputPath)),

--- a/src/NextjsLambda.ts
+++ b/src/NextjsLambda.ts
@@ -10,6 +10,7 @@ import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 import * as fs from 'fs-extra';
 import { bundleFunction } from './BundleFunction';
+import { LAMBDA_RUNTIME } from './constants';
 import { CONFIG_ENV_JSON_PATH } from './Nextjs';
 import { NextjsBaseProps } from './NextjsBase';
 import { createArchive, NextjsBuild } from './NextjsBuild';
@@ -38,8 +39,6 @@ export interface NextjsLambdaProps extends NextjsBaseProps {
    */
   readonly lambda?: FunctionOptions;
 }
-
-const RUNTIME = lambda.Runtime.NODEJS_16_X;
 
 /**
  * Build a lambda function from a NextJS application to handle server-side rendering, API routes, and image optimization.
@@ -105,7 +104,7 @@ export class NextJsLambda extends Construct {
     const fn = new Function(scope, 'ServerHandler', {
       memorySize: functionOptions?.memorySize || 1024,
       timeout: functionOptions?.timeout ?? Duration.seconds(10),
-      runtime: RUNTIME,
+      runtime: LAMBDA_RUNTIME,
       handler: path.join(props.nextjsPath, 'server.handler'),
       code,
       environment,

--- a/src/NextjsLayer.ts
+++ b/src/NextjsLayer.ts
@@ -16,7 +16,6 @@ export class NextjsLayer extends LayerVersion {
     const layerDir = path.resolve(__dirname, '../assets');
     super(scope, id, {
       code: new lambda.AssetCode(path.join(layerDir, 'sharp-0.30.0.zip')),
-      compatibleRuntimes: [lambda.Runtime.NODEJS_16_X, lambda.Runtime.NODEJS_18_X],
       description: 'Sharp for Lambdas',
       ...props,
     });

--- a/src/NextjsS3EnvRewriter.ts
+++ b/src/NextjsS3EnvRewriter.ts
@@ -6,6 +6,7 @@ import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import * as cr from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { bundleFunction } from './BundleFunction';
+import { LAMBDA_RUNTIME } from './constants';
 import { NextjsBaseProps } from './NextjsBase';
 import { makeTokenPlaceholder, NextjsBuild } from './NextjsBuild';
 
@@ -65,7 +66,7 @@ export class NextjsS3EnvRewriter extends Construct {
 
     // rewriter lambda function
     const rewriteFn = new lambda.Function(this, 'RewriteOnEventHandler', {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: LAMBDA_RUNTIME,
       memorySize: 1024,
       timeout: Duration.minutes(5),
       handler: 'S3EnvRewriter.handler',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,7 @@
 import { Duration } from 'aws-cdk-lib';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 export const DEFAULT_STATIC_MAX_AGE = Duration.days(30).toSeconds();
 export const DEFAULT_STATIC_STALE_WHILE_REVALIDATE = Duration.days(1).toSeconds();
+
+export const LAMBDA_RUNTIME = Runtime.NODEJS_16_X;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,21 +10,6 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/asset-awscli-v1@^2.2.9":
-  version "2.2.26"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.26.tgz#4d1f36915ef6046b728a61be19d689e1128b0bf7"
-  integrity sha512-j6bp4iDIZlqAlmACpBCZuCZjLYNeJccQFAPmvgjG9edLBGvVyJZvBT7m39lVtjfEyl8EyznCv7czOFaKsZH2Zg==
-
-"@aws-cdk/asset-kubectl-v20@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz#d01c1efb867fb7f2cfd8c8b230b8eae16447e156"
-  integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
-
-"@aws-cdk/asset-node-proxy-agent-v5@^2.0.15":
-  version "2.0.32"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.32.tgz#9ee62c3b709c8fc4c4e348e6a980a7d06b9290e6"
-  integrity sha512-w1MaBSyR1vT+glPBNd0smp9MPWbz1z/o3+N59MYpjtA4lW845hb8LwthzvbPUzb0YglUfrnOj64i9BFe6BXeZA==
-
 "@aws-crypto/crc32@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-2.0.0.tgz#4ad432a3c03ec3087c5540ff6e41e6565d2dc153"
@@ -2230,14 +2215,11 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.53.0:
-  version "2.53.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.53.0.tgz#c36ecfb87ba4e7d1cdfe0c620161beda0ce4aa67"
-  integrity sha512-ADpJ9luJxzmOrP/GJ37nA1YtdNmsOsjE+NZnQOpB7YL0spUxZJGNVAselaFLSDZmIsC6d9mSnW81fj4SDP1gAw==
+aws-cdk-lib@2.50.0:
+  version "2.50.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.50.0.tgz#2b3a9ba4c1c4c56fd32e3e4f57eea8bf9fa3dbba"
+  integrity sha512-deDbZTI7oyu3rqUyqjwhP6tnUO8MD70lE98yR65xiYty4yXBpsWKbeH3s1wNLpLAWS3hWJYyMtjZ4ZfC35NtVg==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.9"
-    "@aws-cdk/asset-kubectl-v20" "^2.1.1"
-    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.15"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"


### PR DESCRIPTION
If not using super latest aws-cdk-lib then you can't deploy since the node_18_x runtime isn't defined