### PR TITLE
fix: Skip image fn bundling if placeholder

### DIFF
--- a/assets/lambda/ImageOptimization/placeholder.ts
+++ b/assets/lambda/ImageOptimization/placeholder.ts
@@ -1,0 +1,6 @@
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => ({
+  statusCode: 200,
+  body: 'Placeholder function is deployed',
+});

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -66,10 +66,13 @@ export class ImageOptimizationLambda extends NodejsFunction {
     if (!fs.existsSync(target)) fs.symlinkSync(source, target, 'dir');
 
     super(scope, id, {
-      entry: imageOptHandlerPath,
+      entry: isPlaceholder
+        ? path.join(__dirname, '../assets/lambda/ImageOptimization/placeholder.ts')
+        : imageOptHandlerPath,
       runtime: LAMBDA_RUNTIME,
       bundling: isPlaceholder
-        ? {
+        ? undefined
+        : {
             commandHooks: {
               beforeBundling(_: string, outputDir: string): string[] {
                 // Saves the required-server-files.json to the .next folder
@@ -86,8 +89,7 @@ export class ImageOptimizationLambda extends NodejsFunction {
             minify: true,
             target: 'node18',
             externalModules: ['@aws-sdk/client-s3'],
-          }
-        : undefined,
+          },
       layers: [props.nextLayer],
       ...lambdaOptions,
       // defaults

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -87,7 +87,7 @@ export class ImageOptimizationLambda extends NodejsFunction {
               },
             },
             minify: true,
-            target: 'node18',
+            target: 'node16',
             externalModules: ['@aws-sdk/client-s3'],
           },
       layers: [props.nextLayer],

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -47,7 +47,7 @@ export class ImageOptimizationLambda extends NodejsFunction {
   bucket: IBucket;
 
   constructor(scope: Construct, id: string, props: ImageOptimizationProps) {
-    const { lambdaOptions, bucket } = props;
+    const { lambdaOptions, bucket, isPlaceholder } = props;
     const lambdaPath = path.resolve(__dirname, '../assets/lambda/ImageOptimization');
     const imageOptHandlerPath = path.resolve(lambdaPath, 'index.ts');
 
@@ -68,24 +68,26 @@ export class ImageOptimizationLambda extends NodejsFunction {
     super(scope, id, {
       entry: imageOptHandlerPath,
       runtime: LAMBDA_RUNTIME,
-      bundling: {
-        commandHooks: {
-          beforeBundling(_: string, outputDir: string): string[] {
-            // Saves the required-server-files.json to the .next folder
-            const filePath = path.join(props.nextBuild.nextStandaloneBuildDir, 'required-server-files.json');
-            return [`mkdir -p "${outputDir}/.next"`, `cp "${filePath}" "${outputDir}/.next"`];
-          },
-          afterBundling() {
-            return [];
-          },
-          beforeInstall() {
-            return [];
-          },
-        },
-        minify: true,
-        target: 'node18',
-        externalModules: ['@aws-sdk/client-s3'],
-      },
+      bundling: isPlaceholder
+        ? {
+            commandHooks: {
+              beforeBundling(_: string, outputDir: string): string[] {
+                // Saves the required-server-files.json to the .next folder
+                const filePath = path.join(props.nextBuild.nextStandaloneBuildDir, 'required-server-files.json');
+                return [`mkdir -p "${outputDir}/.next"`, `cp "${filePath}" "${outputDir}/.next"`];
+              },
+              afterBundling() {
+                return [];
+              },
+              beforeInstall() {
+                return [];
+              },
+            },
+            minify: true,
+            target: 'node18',
+            externalModules: ['@aws-sdk/client-s3'],
+          }
+        : undefined,
       layers: [props.nextLayer],
       ...lambdaOptions,
       // defaults


### PR DESCRIPTION
We can skip some image fn bundling stuff if we're just building a placeholder (`sst start`)

```
cp: cannot stat '/home/cyber/dev/packages/frontend/.next/standalone/packages/frontend/.next/required-server-files.json': No such file or directory
```