### PR TITLE
fix: Output paths

### DIFF
--- a/API.md
+++ b/API.md
@@ -1520,12 +1520,14 @@ Any object.
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.buildPath">buildPath</a></code> | <code>string</code> | The path to the directory where the server build artifacts are stored. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextDir">nextDir</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextDirRelative">nextDirRelative</a></code> | <code>string</code> | Relative path from project root to nextjs project. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextPublicDir">nextPublicDir</a></code> | <code>string</code> | Public static files. |
-| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneBuildDir">nextStandaloneBuildDir</a></code> | <code>string</code> | NextJS project inside of standalone build. |
-| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneDir">nextStandaloneDir</a></code> | <code>string</code> | Entire NextJS build output directory. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneBuildDir">nextStandaloneBuildDir</a></code> | <code>string</code> | NextJS build inside of standalone build. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneDir">nextStandaloneDir</a></code> | <code>string</code> | NextJS project inside of standalone build. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStaticDir">nextStaticDir</a></code> | <code>string</code> | Static files containing client-side code. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.projectRoot">projectRoot</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.props">props</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps">NextjsBuildProps</a></code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.standaloneDir">standaloneDir</a></code> | <code>string</code> | Entire NextJS build output directory. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | *No description.* |
 
 ---
@@ -1564,6 +1566,20 @@ public readonly nextDir: string;
 
 ---
 
+##### `nextDirRelative`<sup>Required</sup> <a name="nextDirRelative" id="cdk-nextjs-standalone.NextjsBuild.property.nextDirRelative"></a>
+
+```typescript
+public readonly nextDirRelative: string;
+```
+
+- *Type:* string
+
+Relative path from project root to nextjs project.
+
+e.g. 'web' or 'packages/web' or '.'
+
+---
+
 ##### `nextPublicDir`<sup>Required</sup> <a name="nextPublicDir" id="cdk-nextjs-standalone.NextjsBuild.property.nextPublicDir"></a>
 
 ```typescript
@@ -1586,7 +1602,7 @@ public readonly nextStandaloneBuildDir: string;
 
 - *Type:* string
 
-NextJS project inside of standalone build.
+NextJS build inside of standalone build.
 
 Contains server code and manifests.
 
@@ -1600,9 +1616,9 @@ public readonly nextStandaloneDir: string;
 
 - *Type:* string
 
-Entire NextJS build output directory.
+NextJS project inside of standalone build.
 
-Contains server and client code and manifests.
+Contains .next build and server code and traced dependencies.
 
 ---
 
@@ -1635,6 +1651,20 @@ public readonly props: NextjsBuildProps;
 ```
 
 - *Type:* <a href="#cdk-nextjs-standalone.NextjsBuildProps">NextjsBuildProps</a>
+
+---
+
+##### `standaloneDir`<sup>Required</sup> <a name="standaloneDir" id="cdk-nextjs-standalone.NextjsBuild.property.standaloneDir"></a>
+
+```typescript
+public readonly standaloneDir: string;
+```
+
+- *Type:* string
+
+Entire NextJS build output directory.
+
+Contains server and client code and manifests.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -1524,6 +1524,7 @@ Any object.
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneBuildDir">nextStandaloneBuildDir</a></code> | <code>string</code> | NextJS project inside of standalone build. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneDir">nextStandaloneDir</a></code> | <code>string</code> | Entire NextJS build output directory. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStaticDir">nextStaticDir</a></code> | <code>string</code> | Static files containing client-side code. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.projectRoot">projectRoot</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.props">props</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps">NextjsBuildProps</a></code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | *No description.* |
 
@@ -1614,6 +1615,16 @@ public readonly nextStaticDir: string;
 - *Type:* string
 
 Static files containing client-side code.
+
+---
+
+##### `projectRoot`<sup>Required</sup> <a name="projectRoot" id="cdk-nextjs-standalone.NextjsBuild.property.projectRoot"></a>
+
+```typescript
+public readonly projectRoot: string;
+```
+
+- *Type:* string
 
 ---
 
@@ -2639,6 +2650,7 @@ const imageOptimizationProps: ImageOptimizationProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | Custom environment variables to pass to the NextJS build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.isPlaceholder">isPlaceholder</a></code> | <code>boolean</code> | Skip building app and deploy a placeholder. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The S3 bucket holding application images. |
@@ -2672,7 +2684,7 @@ public readonly buildPath: string;
 
 The directory to execute `npm run build` from.
 
-By default, it uses `nextjsPath`.
+By default, it is `nextjsPath`.
 Can be overridden, particularly useful for monorepos where `build` is expected to run
 at the root of the project.
 
@@ -2726,6 +2738,20 @@ public readonly nodeEnv: string;
 - *Type:* string
 
 Optional value for NODE_ENV during build and runtime.
+
+---
+
+##### `projectRoot`<sup>Optional</sup> <a name="projectRoot" id="cdk-nextjs-standalone.ImageOptimizationProps.property.projectRoot"></a>
+
+```typescript
+public readonly projectRoot: string;
+```
+
+- *Type:* string
+
+Root of your project, if different from `nextjsPath`.
+
+Defaults to current working directory.
 
 ---
 
@@ -2870,6 +2896,7 @@ const nextjsAssetsDeploymentProps: NextjsAssetsDeploymentProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | Custom environment variables to pass to the NextJS build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.isPlaceholder">isPlaceholder</a></code> | <code>boolean</code> | Skip building app and deploy a placeholder. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Properties for the S3 bucket containing the NextJS assets. |
@@ -2904,7 +2931,7 @@ public readonly buildPath: string;
 
 The directory to execute `npm run build` from.
 
-By default, it uses `nextjsPath`.
+By default, it is `nextjsPath`.
 Can be overridden, particularly useful for monorepos where `build` is expected to run
 at the root of the project.
 
@@ -2958,6 +2985,20 @@ public readonly nodeEnv: string;
 - *Type:* string
 
 Optional value for NODE_ENV during build and runtime.
+
+---
+
+##### `projectRoot`<sup>Optional</sup> <a name="projectRoot" id="cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.projectRoot"></a>
+
+```typescript
+public readonly projectRoot: string;
+```
+
+- *Type:* string
+
+Root of your project, if different from `nextjsPath`.
+
+Defaults to current working directory.
 
 ---
 
@@ -3071,6 +3112,7 @@ const nextjsBaseProps: NextjsBaseProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | Custom environment variables to pass to the NextJS build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.isPlaceholder">isPlaceholder</a></code> | <code>boolean</code> | Skip building app and deploy a placeholder. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 
@@ -3100,7 +3142,7 @@ public readonly buildPath: string;
 
 The directory to execute `npm run build` from.
 
-By default, it uses `nextjsPath`.
+By default, it is `nextjsPath`.
 Can be overridden, particularly useful for monorepos where `build` is expected to run
 at the root of the project.
 
@@ -3157,6 +3199,20 @@ Optional value for NODE_ENV during build and runtime.
 
 ---
 
+##### `projectRoot`<sup>Optional</sup> <a name="projectRoot" id="cdk-nextjs-standalone.NextjsBaseProps.property.projectRoot"></a>
+
+```typescript
+public readonly projectRoot: string;
+```
+
+- *Type:* string
+
+Root of your project, if different from `nextjsPath`.
+
+Defaults to current working directory.
+
+---
+
 ##### `quiet`<sup>Optional</sup> <a name="quiet" id="cdk-nextjs-standalone.NextjsBaseProps.property.quiet"></a>
 
 ```typescript
@@ -3203,6 +3259,7 @@ const nextjsBuildProps: NextjsBuildProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | Custom environment variables to pass to the NextJS build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.isPlaceholder">isPlaceholder</a></code> | <code>boolean</code> | Skip building app and deploy a placeholder. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 
@@ -3232,7 +3289,7 @@ public readonly buildPath: string;
 
 The directory to execute `npm run build` from.
 
-By default, it uses `nextjsPath`.
+By default, it is `nextjsPath`.
 Can be overridden, particularly useful for monorepos where `build` is expected to run
 at the root of the project.
 
@@ -3286,6 +3343,20 @@ public readonly nodeEnv: string;
 - *Type:* string
 
 Optional value for NODE_ENV during build and runtime.
+
+---
+
+##### `projectRoot`<sup>Optional</sup> <a name="projectRoot" id="cdk-nextjs-standalone.NextjsBuildProps.property.projectRoot"></a>
+
+```typescript
+public readonly projectRoot: string;
+```
+
+- *Type:* string
+
+Root of your project, if different from `nextjsPath`.
+
+Defaults to current working directory.
 
 ---
 
@@ -3492,6 +3563,7 @@ const nextjsDistributionProps: NextjsDistributionProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | Custom environment variables to pass to the NextJS build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.isPlaceholder">isPlaceholder</a></code> | <code>boolean</code> | Skip building app and deploy a placeholder. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.imageOptFunction">imageOptFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | Lambda function to optimize images. |
@@ -3530,7 +3602,7 @@ public readonly buildPath: string;
 
 The directory to execute `npm run build` from.
 
-By default, it uses `nextjsPath`.
+By default, it is `nextjsPath`.
 Can be overridden, particularly useful for monorepos where `build` is expected to run
 at the root of the project.
 
@@ -3584,6 +3656,20 @@ public readonly nodeEnv: string;
 - *Type:* string
 
 Optional value for NODE_ENV during build and runtime.
+
+---
+
+##### `projectRoot`<sup>Optional</sup> <a name="projectRoot" id="cdk-nextjs-standalone.NextjsDistributionProps.property.projectRoot"></a>
+
+```typescript
+public readonly projectRoot: string;
+```
+
+- *Type:* string
+
+Root of your project, if different from `nextjsPath`.
+
+Defaults to current working directory.
 
 ---
 
@@ -3877,6 +3963,7 @@ const nextjsLambdaProps: NextjsLambdaProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | Custom environment variables to pass to the NextJS build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.isPlaceholder">isPlaceholder</a></code> | <code>boolean</code> | Skip building app and deploy a placeholder. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built nextJS application. |
@@ -3908,7 +3995,7 @@ public readonly buildPath: string;
 
 The directory to execute `npm run build` from.
 
-By default, it uses `nextjsPath`.
+By default, it is `nextjsPath`.
 Can be overridden, particularly useful for monorepos where `build` is expected to run
 at the root of the project.
 
@@ -3962,6 +4049,20 @@ public readonly nodeEnv: string;
 - *Type:* string
 
 Optional value for NODE_ENV during build and runtime.
+
+---
+
+##### `projectRoot`<sup>Optional</sup> <a name="projectRoot" id="cdk-nextjs-standalone.NextjsLambdaProps.property.projectRoot"></a>
+
+```typescript
+public readonly projectRoot: string;
+```
+
+- *Type:* string
+
+Root of your project, if different from `nextjsPath`.
+
+Defaults to current working directory.
 
 ---
 
@@ -4046,6 +4147,7 @@ const nextjsProps: NextjsProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | Custom environment variables to pass to the NextJS build and runtime. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.isPlaceholder">isPlaceholder</a></code> | <code>boolean</code> | Skip building app and deploy a placeholder. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.NextjsProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.defaults">defaults</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsDefaultsProps">NextjsDefaultsProps</a></code> | Allows you to override defaults for the resources created by this construct. |
@@ -4077,7 +4179,7 @@ public readonly buildPath: string;
 
 The directory to execute `npm run build` from.
 
-By default, it uses `nextjsPath`.
+By default, it is `nextjsPath`.
 Can be overridden, particularly useful for monorepos where `build` is expected to run
 at the root of the project.
 
@@ -4131,6 +4233,20 @@ public readonly nodeEnv: string;
 - *Type:* string
 
 Optional value for NODE_ENV during build and runtime.
+
+---
+
+##### `projectRoot`<sup>Optional</sup> <a name="projectRoot" id="cdk-nextjs-standalone.NextjsProps.property.projectRoot"></a>
+
+```typescript
+public readonly projectRoot: string;
+```
+
+- *Type:* string
+
+Root of your project, if different from `nextjsPath`.
+
+Defaults to current working directory.
 
 ---
 

--- a/src/BundleFunction.ts
+++ b/src/BundleFunction.ts
@@ -41,7 +41,7 @@ export function bundleFunction({ inputPath, outputPath, outputFilename, bundleOp
     throw new Error('There was a problem bundling the function.');
   }
 
-  console.debug('Bundled ', inputPath, 'to', outputPath);
+  // console.debug('Bundled ', inputPath, 'to', outputPath);
 
   return dirname(outputPath);
 }

--- a/src/BundleFunction.ts
+++ b/src/BundleFunction.ts
@@ -41,7 +41,7 @@ export function bundleFunction({ inputPath, outputPath, outputFilename, bundleOp
     throw new Error('There was a problem bundling the function.');
   }
 
-  // console.debug('Bundled ', inputPath, 'to', outputPath);
+  console.debug('Bundled ', inputPath, 'to', outputPath);
 
   return dirname(outputPath);
 }

--- a/src/NextjsBase.ts
+++ b/src/NextjsBase.ts
@@ -15,11 +15,17 @@ export interface NextjsBaseProps {
   readonly nextjsPath: string;
 
   /**
-   * The directory to execute `npm run build` from. By default, it uses `nextjsPath`.
+   * The directory to execute `npm run build` from. By default, it is `nextjsPath`.
    * Can be overridden, particularly useful for monorepos where `build` is expected to run
    * at the root of the project.
    */
   readonly buildPath?: string;
+
+  /**
+   * Root of your project, if different from `nextjsPath`.
+   * Defaults to current working directory.
+   */
+  readonly projectRoot?: string;
 
   /**
    * Custom environment variables to pass to the NextJS build and runtime.

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -33,9 +33,14 @@ export class NextjsBuild extends Construct {
    * Entire NextJS build output directory.
    * Contains server and client code and manifests.
    */
-  public nextStandaloneDir: string;
+  public standaloneDir: string;
   /**
    * NextJS project inside of standalone build.
+   * Contains .next build and server code and traced dependencies.
+   */
+  public nextStandaloneDir: string;
+  /**
+   * NextJS build inside of standalone build.
    * Contains server code and manifests.
    */
   public nextStandaloneBuildDir: string;
@@ -48,6 +53,11 @@ export class NextjsBuild extends Construct {
    * E.g. robots.txt, favicon.ico, etc.
    */
   public nextPublicDir: string;
+  /**
+   * Relative path from project root to nextjs project.
+   * e.g. 'web' or 'packages/web' or '.'
+   */
+  public nextDirRelative: string;
 
   public props: NextjsBuildProps;
 
@@ -81,8 +91,10 @@ export class NextjsBuild extends Construct {
       throw new Error(`No server build output found at "${serverBuildDir}"`);
 
     // our outputs
+    this.standaloneDir = this._getStandaloneDir();
     this.nextStandaloneDir = this._getNextStandaloneDir();
     this.nextStandaloneBuildDir = this._getNextStandaloneBuildDir();
+    this.nextDirRelative = this._getNextDirRelative();
     this.nextPublicDir = this._getNextPublicDir();
     this.nextStaticDir = this._getNextStaticDir();
     this.buildPath = this.nextStandaloneBuildDir;
@@ -168,7 +180,7 @@ export class NextjsBuild extends Construct {
   }
 
   // output of nextjs standalone build
-  private _getNextStandaloneDir() {
+  private _getStandaloneDir() {
     const nextDir = this._getNextBuildDir();
     const standaloneDir = path.join(nextDir, NEXTJS_BUILD_STANDALONE_DIR);
 
@@ -178,17 +190,23 @@ export class NextjsBuild extends Construct {
     return standaloneDir;
   }
 
-  // nextjs project inside of standalone build
+  // .next/ directory inside of standalone build output directory
   // contains manifests and server code
   private _getNextStandaloneBuildDir() {
-    const standaloneDir = this._getNextStandaloneDir();
+    return path.join(this._getNextStandaloneDir(), NEXTJS_BUILD_DIR); // e.g. /home/me/myapp/web/.next/standalone/web/.next
+  }
+
+  // nextjs project inside of standalone build
+  // contains manifests and server code
+  private _getNextStandaloneDir() {
+    const standaloneDir = this._getStandaloneDir();
 
     // if the project is at /home/me/myapp and the nextjs project is at /home/me/myapp/web
     // the standalone build of the web app will be at /home/me/myapp/web/.next/standalone/web
     // so we need to get the relative path from the standalone dir to the nextjsPath
     const relativePath = this._getNextDirRelative(); // e.g. 'web
     const standaloneProjectDir = path.join(standaloneDir, relativePath); // e.g. /home/me/myapp/web/.next/standalone/web
-    return path.join(standaloneProjectDir, NEXTJS_BUILD_DIR); // e.g. /home/me/myapp/web/.next/standalone/web/.next
+    return standaloneProjectDir;
   }
 
   // contains static files

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -244,6 +244,11 @@ export function createArchive({
   // get output path
   const zipFilePath = path.join(zipOutDir, zipFileName);
 
+  // delete existing zip file
+  if (fs.existsSync(zipFilePath)) {
+    fs.unlinkSync(zipFilePath);
+  }
+
   // run script to create zipfile, preserving symlinks for node_modules (e.g. pnpm structure)
   const result = spawn.sync(
     'bash', // getting ENOENT when specifying 'node' here for some reason

--- a/src/NextjsLambda.ts
+++ b/src/NextjsLambda.ts
@@ -50,10 +50,9 @@ export class NextJsLambda extends Construct {
   constructor(scope: Construct, id: string, props: NextjsLambdaProps) {
     super(scope, id);
     const { nextBuild, lambda: functionOptions, isPlaceholder } = props;
-
     // bundle server handler
     // delete default nextjs handler if it exists
-    const defaultServerPath = path.join(nextBuild.nextStandaloneDir, props.nextjsPath, 'server.js');
+    const defaultServerPath = path.join(nextBuild.nextStandaloneDir, 'server.js');
     if (fs.existsSync(defaultServerPath)) {
       fs.unlinkSync(defaultServerPath);
     }
@@ -61,10 +60,10 @@ export class NextJsLambda extends Construct {
     // build our server handler in build.nextStandaloneDir
     const serverHandler = path.resolve(__dirname, '../assets/lambda/NextJsHandler.ts');
     // server should live in the same dir as the nextjs app to access deps properly
-    const serverPath = path.join(props.nextjsPath, 'server.cjs');
+    const serverPath = path.join(nextBuild.nextStandaloneDir, 'server.cjs');
     bundleFunction({
       inputPath: serverHandler,
-      outputPath: path.join(nextBuild.nextStandaloneDir, serverPath),
+      outputPath: serverPath,
       bundleOptions: {
         bundle: true,
         minify: false,
@@ -83,7 +82,7 @@ export class NextJsLambda extends Construct {
         : fs.mkdtempSync(path.join(os.tmpdir(), 'standalone-'))
     );
     const zipFilePath = createArchive({
-      directory: nextBuild.nextStandaloneDir,
+      directory: nextBuild.standaloneDir,
       zipFileName: 'standalone.zip',
       zipOutDir,
       fileGlob: '*',

--- a/src/NextjsLambda.ts
+++ b/src/NextjsLambda.ts
@@ -60,7 +60,7 @@ export class NextJsLambda extends Construct {
     // build our server handler in build.nextStandaloneDir
     const serverHandler = path.resolve(__dirname, '../assets/lambda/NextJsHandler.ts');
     // server should live in the same dir as the nextjs app to access deps properly
-    const serverPath = path.join(nextBuild.nextStandaloneDir, 'server.cjs');
+    const serverPath = path.join(nextBuild.nextStandaloneDir, 'server.js');
     bundleFunction({
       inputPath: serverHandler,
       outputPath: serverPath,
@@ -104,7 +104,7 @@ export class NextJsLambda extends Construct {
       memorySize: functionOptions?.memorySize || 1024,
       timeout: functionOptions?.timeout ?? Duration.seconds(10),
       runtime: LAMBDA_RUNTIME,
-      handler: path.join(props.nextjsPath, 'server.handler'),
+      handler: path.join(nextBuild.nextDirRelative, 'server.handler'),
       code,
       environment,
 


### PR DESCRIPTION
Trying to make it clearer what's going on with the path relative to the output tracing root inside the standalone output directory.

Helps with the error about missing `required-server-files.json` (at least for me, please try it)

Fixes #61 

Please try this and let me know if it works for your setup! 