### PR TITLE
fix: remove `nextjsPath` from `nextStandaloneBuildDir`

### DIFF
--- a/API.md
+++ b/API.md
@@ -1519,6 +1519,7 @@ Any object.
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.buildPath">buildPath</a></code> | <code>string</code> | The path to the directory where the server build artifacts are stored. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextBuildDir">nextBuildDir</a></code> | <code>string</code> | The path the `.next` directory of the Nextjs application. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextDir">nextDir</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextPublicDir">nextPublicDir</a></code> | <code>string</code> | Public static files. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStandaloneBuildDir">nextStandaloneBuildDir</a></code> | <code>string</code> | NextJS project inside of standalone build. |
@@ -1550,6 +1551,18 @@ public readonly buildPath: string;
 - *Type:* string
 
 The path to the directory where the server build artifacts are stored.
+
+---
+
+##### `nextBuildDir`<sup>Required</sup> <a name="nextBuildDir" id="cdk-nextjs-standalone.NextjsBuild.property.nextBuildDir"></a>
+
+```typescript
+public readonly nextBuildDir: string;
+```
+
+- *Type:* string
+
+The path the `.next` directory of the Nextjs application.
 
 ---
 

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -76,7 +76,7 @@ export class ImageOptimizationLambda extends NodejsFunction {
             commandHooks: {
               beforeBundling(_: string, outputDir: string): string[] {
                 // Saves the required-server-files.json to the .next folder
-                const filePath = path.join(props.nextBuild.nextStandaloneBuildDir, 'required-server-files.json');
+                const filePath = path.join(props.nextBuild.nextBuildDir, 'required-server-files.json');
                 return [`mkdir -p "${outputDir}/.next"`, `cp "${filePath}" "${outputDir}/.next"`];
               },
               afterBundling() {

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -55,6 +55,11 @@ export class NextjsBuild extends Construct {
 
   public nextDir: string;
 
+  /**
+   * The path the `.next` directory of the Nextjs application.
+   */
+  public nextBuildDir: string;
+
   constructor(scope: Construct, id: string, props: NextjsBuildProps) {
     super(scope, id);
 
@@ -66,15 +71,18 @@ export class NextjsBuild extends Construct {
 
     // validate paths
     const baseOutputDir = path.resolve(this.props.nextjsPath);
-    if (!fs.existsSync(baseOutputDir)) throw new Error(`NextJS application not found at "${baseOutputDir}"`);
+    if (!fs.existsSync(baseOutputDir)) {
+      throw new Error(`NextJS application not found at "${baseOutputDir}"`);
+    }
 
     // build app
     this.runNpmBuild();
 
     // check for output
     const serverBuildDir = path.join(baseOutputDir, NEXTJS_BUILD_DIR);
-    if (!props.isPlaceholder && !fs.existsSync(serverBuildDir))
+    if (!props.isPlaceholder && !fs.existsSync(serverBuildDir)) {
       throw new Error(`No server build output found at "${serverBuildDir}"`);
+    }
 
     // our outputs
     this.nextStandaloneDir = this._getNextStandaloneDir();
@@ -83,13 +91,16 @@ export class NextjsBuild extends Construct {
     this.nextStaticDir = this._getNextStaticDir();
     this.buildPath = this.nextStandaloneBuildDir;
     this.nextDir = this._getNextDir();
+    this.nextBuildDir = this._getNextBuildDir();
   }
 
   private runNpmBuild() {
     const { nextjsPath, isPlaceholder, quiet } = this.props;
 
     if (isPlaceholder) {
-      if (!quiet) console.debug(`Skipping build for placeholder NextjsBuild at ${nextjsPath}`);
+      if (!quiet) {
+        console.debug(`Skipping build for placeholder NextjsBuild at ${nextjsPath}`);
+      }
       return;
     }
 
@@ -199,7 +210,9 @@ export function createArchive({
   quiet,
 }: CreateArchiveArgs): string | null {
   // if directory is empty, can skip
-  if (!fs.existsSync(directory) || fs.readdirSync(directory).length === 0) return null;
+  if (!fs.existsSync(directory) || fs.readdirSync(directory).length === 0) {
+    return null;
+  }
 
   zipOutDir = path.resolve(zipOutDir);
   fs.mkdirpSync(zipOutDir);

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -71,18 +71,14 @@ export class NextjsBuild extends Construct {
 
     // validate paths
     const baseOutputDir = path.resolve(this.props.nextjsPath);
-    if (!fs.existsSync(baseOutputDir)) {
-      throw new Error(`NextJS application not found at "${baseOutputDir}"`);
-    }
+    if (!fs.existsSync(baseOutputDir)) throw new Error(`NextJS application not found at "${baseOutputDir}"`);
 
     // build app
     this.runNpmBuild();
 
     // check for output
     const serverBuildDir = path.join(baseOutputDir, NEXTJS_BUILD_DIR);
-    if (!props.isPlaceholder && !fs.existsSync(serverBuildDir)) {
-      throw new Error(`No server build output found at "${serverBuildDir}"`);
-    }
+    if (!props.isPlaceholder && !fs.existsSync(serverBuildDir)) throw new Error(`No server build output found at "${serverBuildDir}"`);
 
     // our outputs
     this.nextStandaloneDir = this._getNextStandaloneDir();
@@ -98,9 +94,7 @@ export class NextjsBuild extends Construct {
     const { nextjsPath, isPlaceholder, quiet } = this.props;
 
     if (isPlaceholder) {
-      if (!quiet) {
-        console.debug(`Skipping build for placeholder NextjsBuild at ${nextjsPath}`);
-      }
+      if (!quiet) console.debug(`Skipping build for placeholder NextjsBuild at ${nextjsPath}`);
       return;
     }
 
@@ -210,9 +204,7 @@ export function createArchive({
   quiet,
 }: CreateArchiveArgs): string | null {
   // if directory is empty, can skip
-  if (!fs.existsSync(directory) || fs.readdirSync(directory).length === 0) {
-    return null;
-  }
+  if (!fs.existsSync(directory) || fs.readdirSync(directory).length === 0) return null;
 
   zipOutDir = path.resolve(zipOutDir);
   fs.mkdirpSync(zipOutDir);


### PR DESCRIPTION
Fixes #61 

Removes addition of `nextjsPath` to `nextStandaloneBuildDir` because it is already in `nextStandaloneDir`
