### PR TITLE
chore: be explicit about esbuild version and lock it to specific version

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -146,6 +146,7 @@
     },
     {
       "name": "esbuild",
+      "version": "0.15.18",
       "type": "bundled"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -248,19 +248,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='aws-cdk-lib,constructs,esbuild'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='aws-cdk-lib,constructs,esbuild'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='aws-cdk-lib,constructs,esbuild'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='aws-cdk-lib,constructs,esbuild'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='aws-cdk-lib,constructs,esbuild'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -30,7 +30,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     '@types/fs-extra',
     '@types/micromatch',
     '@types/aws-lambda',
-    'esbuild',
+    'esbuild@0.15.18',
     'aws-lambda',
     'serverless-http',
     'jszip',

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Uses the [standalone output](https://nextjs.org/docs/advanced-features/output-fi
 
 ## Quickstart
 
+Add the dependency `esbuild@0.15.18` to your project along with `cdk-nextjs-standalone`.
+
 ```ts
 import path from 'path';
 import { Nextjs } from 'cdk-nextjs-standalone';

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/micromatch": "^4.0.2",
     "aws-lambda": "^1.0.7",
     "cross-spawn": "^7.0.3",
-    "esbuild": "^0.15.16",
+    "esbuild": "0.15.18",
     "fs-extra": "^10.1.0",
     "glob": "^8.0.3",
     "indent-string": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,7 +3383,7 @@ esbuild-windows-arm64@0.15.18:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz#5b5bdc56d341d0922ee94965c89ee120a6a86eb7"
   integrity sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==
 
-esbuild@^0.15.16:
+esbuild@0.15.18:
   version "0.15.18"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.15.18.tgz#ea894adaf3fbc036d32320a00d4d6e4978a2f36d"
   integrity sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==


### PR DESCRIPTION
Still not great

Open to suggestions for making esbuild not bundled with cdk-nextjs in #36