### PR TITLE
fix: Make sure lambda always has a dependency on S3 assets

### DIFF
--- a/src/Nextjs.ts
+++ b/src/Nextjs.ts
@@ -157,7 +157,11 @@ export class Nextjs extends Construct {
     // finish static deployment BEFORE deploying new function code
     // as there is some time after the new static files are uploaded but before they are rewritten
     const rewriter = this.assetsDeployment.rewriter?.rewriteNode;
-    if (rewriter) this.serverFunction.lambdaFunction.node.addDependency(rewriter);
+    if (rewriter) {
+      this.serverFunction.lambdaFunction.node.addDependency(rewriter);
+    } else {
+      this.serverFunction.lambdaFunction.node.addDependency(...this.assetsDeployment.deployments);
+    }
 
     this.distribution = new NextjsDistribution(this, 'Distribution', {
       ...props,


### PR DESCRIPTION
Fixes #84 (again 😅)

PR https://github.com/jetbridge/cdk-nextjs/pull/86 introduced a better way to ensure deploy dependencies between the Lambda server function and the Env Rewriter.

However after this change, if you don't pass anything to `props.environment`, your `rewriter` will be falsey and you will not get any server => S3 dependencies added due to the if condition.

This change makes sure you will either get a dependency on the rewriter if you have one, else just the S3 deployment itself.