### PR TITLE
fix: Allow alternate domain names in the distribution

### DIFF
--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -526,7 +526,9 @@ export class NextjsDistribution extends Construct {
     const customDomain =
       typeof this.props.customDomain === 'string' ? this.props.customDomain : this.props.customDomain?.domainName;
 
-    return customDomain ? [customDomain] : [];
+    const alternateNames = typeof this.props.customDomain === 'string' ? [] : this.props.customDomain?.alternateNames;
+
+    return customDomain ? [customDomain, ...alternateNames] : [];
   }
 
   /**

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -526,7 +526,8 @@ export class NextjsDistribution extends Construct {
     const customDomain =
       typeof this.props.customDomain === 'string' ? this.props.customDomain : this.props.customDomain?.domainName;
 
-    const alternateNames = typeof this.props.customDomain === 'string' ? [] : this.props.customDomain?.alternateNames;
+    const alternateNames =
+      typeof this.props.customDomain === 'string' ? [] : this.props.customDomain?.alternateNames || [];
 
     return customDomain ? [customDomain, ...alternateNames] : [];
   }


### PR DESCRIPTION
Fixes #100 

It appears that we can pass in multiple domain names to the cloudfront distribution
https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-cloudfront.Distribution.html#:~:text=g.%2C%20example.com/).-,domainNames%3F,Alternative%20domain%20names%20for%20this%20distribution.,-enableIpv6%3F

Modifies `buildDistributionDomainNames` to combine the list of `alternateNames` with the `customDomain` if they exist