### PR TITLE
feat: add 'rsc', 'next-router-prefetch', 'next-router-state-tree' to lambda cache policy

### DIFF
--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -167,7 +167,7 @@ export class NextjsDistribution extends Construct {
    */
   public static lambdaCachePolicyProps: cloudfront.CachePolicyProps = {
     queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
-    headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+    headerBehavior: cloudfront.CacheHeaderBehavior.allowList('rsc', 'next-router-prefetch', 'next-router-state-tree'),
     cookieBehavior: cloudfront.CacheCookieBehavior.all(),
     defaultTtl: Duration.seconds(0),
     maxTtl: Duration.days(365),


### PR DESCRIPTION
Add 'rsc', 'next-router-prefetch', 'next-router-state-tree' to lambda cache policy

Fixes #106 