### PR TITLE
Initial support for open-next v2 and ISR

### DIFF
--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -52,6 +52,7 @@ export class ImageOptimizationLambda extends Function {
       handler: 'index.handler',
       runtime: LAMBDA_RUNTIME,
       architecture: Architecture.ARM_64,
+      description: 'Next.js Image Optimization Function',
       // prevents "Resolution error: Cannot use resource in a cross-environment
       // fashion, the resource's physical name must be explicit set or use
       // PhysicalName.GENERATE_IF_NEEDED."

--- a/src/NextjsRevaluation.ts
+++ b/src/NextjsRevaluation.ts
@@ -1,0 +1,63 @@
+import { Duration, Stack } from 'aws-cdk-lib';
+import { Code, Function, FunctionOptions, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
+import { Construct } from 'constructs';
+import { NextjsBaseProps } from './NextjsBase';
+import { NextjsBuild } from './NextjsBuild';
+import { NextJsLambda } from './NextjsLambda';
+
+export interface RevaluationProps extends NextjsBaseProps {
+  /**
+   * Override function properties.
+   */
+  readonly lambdaOptions?: FunctionOptions;
+
+  /**
+   * The `NextjsBuild` instance representing the built Nextjs application.
+   */
+  readonly nextBuild: NextjsBuild;
+
+  /**
+   * The main NextJS server handler lambda function.
+   */
+  readonly serverFunction: NextJsLambda;
+}
+
+/**
+ * Builds the system for revaluating Next.js resources. This includes a Lambda function handler and queue system.
+ */
+export class NextjsRevaluation extends Construct {
+  constructor(scope: Construct, id: string, props: RevaluationProps) {
+    super(scope, id);
+
+    if (!props.nextBuild) return;
+
+    const code = props.isPlaceholder
+      ? Code.fromInline(
+          "module.exports.handler = async () => { return { statusCode: 200, body: 'SST placeholder site' } }"
+        )
+      : Code.fromAsset(props.nextBuild.nextImageFnDir);
+
+    const queue = new Queue(this, 'RevalidationQueue', {
+      fifo: true,
+      receiveMessageWaitTime: Duration.seconds(20),
+    });
+    const consumer = new Function(this, 'RevalidationFunction', {
+      description: 'Next.js revalidator',
+      handler: 'index.handler',
+      code,
+      runtime: Runtime.NODEJS_18_X,
+      timeout: Duration.seconds(30),
+      // This, I think, is supposed to be the VPC or VPC Subnet config (https://github.com/serverless-stack/sst/blob/master/packages/sst/src/constructs/NextjsSite.ts#L59C5-L59C17)
+      // ...this.revalidation,
+    });
+    consumer.addEventSource(new SqsEventSource(queue, { batchSize: 5 }));
+
+    // Allow server to send messages to the queue
+    const server = props.serverFunction.lambdaFunction;
+    server?.addEnvironment('REVALIDATION_QUEUE_URL', queue.queueUrl);
+    server?.addEnvironment('REVALIDATION_QUEUE_REGION', Stack.of(this).region);
+    queue.grantSendMessages(server?.role!);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
   NextjsAssetsDeploymentProps,
   NextjsAssetsCachePolicyProps,
 } from './NextjsAssetsDeployment';
+export { NextjsRevaluation, RevaluationProps } from './NextjsRevaluation';
 export { NextjsBuild, NextjsBuildProps, CreateArchiveArgs } from './NextjsBuild';
 export { EnvironmentVars, NextJsLambda, NextjsLambdaProps } from './NextjsLambda';
 export { ImageOptimizationLambda, ImageOptimizationProps } from './ImageOptimizationLambda';


### PR DESCRIPTION
Updates the server handler to include cache bucket configuration, **which is likely not correct as I'm just using the static asset bucket temporarily**. I need to look at how SST does this and what the spirit of this should be, e.g. if a separate bucket would be more appropriate, a folder, etc.

This also adds the ISR handling logic. I haven't actually tested this yet (am not 100% sure how to).

**This is a WIP**.

Fixes #