### PR TITLE
fix: Initial support for open-next v2 and ISR

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -15,7 +15,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     // ignorePatterns: ['assets/**/*']
   },
   majorVersion: 3,
-  // prerelease: 'pre',
+  prerelease: 'beta',
 
   tsconfig: { compilerOptions: { noUnusedLocals: false }, include: ['assets/**/*.ts'] },
   tsconfigDev: { compilerOptions: { noUnusedLocals: false } },
@@ -44,6 +44,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   // do not generate sample test files
   sampleCode: false,
 });
+
 const packageJson = project.tryFindObjectFile('package.json');
 if (packageJson) {
   packageJson.patch(
@@ -53,8 +54,5 @@ if (packageJson) {
     ])
   );
 }
-// project.eslint.addOverride({
-//   rules: {},
-// });
-// project.tsconfig.addInclude('assets/**/*.ts');
+
 project.synth();

--- a/API.md
+++ b/API.md
@@ -1702,7 +1702,7 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextCacheDir">nextCacheDir</a></code> | <code>string</code> | Cache setup directory. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextCacheDir">nextCacheDir</a></code> | <code>string</code> | Cache directory for generated data. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextImageFnDir">nextImageFnDir</a></code> | <code>string</code> | Contains function for processessing image requests. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextRevalidateFnDir">nextRevalidateFnDir</a></code> | <code>string</code> | Contains function for processing items from revalidation queue. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextServerFnDir">nextServerFnDir</a></code> | <code>string</code> | Contains server code and dependencies. |
@@ -1733,7 +1733,7 @@ public readonly nextCacheDir: string;
 
 - *Type:* string
 
-Cache setup directory.
+Cache directory for generated data.
 
 ---
 
@@ -2546,7 +2546,7 @@ The runtimes compatible with this Layer.
 
 ### NextjsRevalidation <a name="NextjsRevalidation" id="cdk-nextjs-standalone.NextjsRevalidation"></a>
 
-Builds the system for revaluating Next.js resources. This includes a Lambda function handler and queue system.
+Builds the system for revalidating Next.js resources. This includes a Lambda function handler and queue system.
 
 > [{@link https://github.com/serverless-stack/open-next/blob/main/README.md?plain=1#L65}]({@link https://github.com/serverless-stack/open-next/blob/main/README.md?plain=1#L65})
 
@@ -3110,7 +3110,7 @@ public readonly buildCommand: string;
 
 Optional value used to install NextJS node dependencies.
 
-It defaults to 'npx --yes open-next@latest build'
+It defaults to 'npx --yes open-next@2 build'
 
 ---
 
@@ -3395,7 +3395,7 @@ public readonly buildCommand: string;
 
 Optional value used to install NextJS node dependencies.
 
-It defaults to 'npx --yes open-next@latest build'
+It defaults to 'npx --yes open-next@2 build'
 
 ---
 
@@ -3700,7 +3700,7 @@ public readonly buildCommand: string;
 
 Optional value used to install NextJS node dependencies.
 
-It defaults to 'npx --yes open-next@latest build'
+It defaults to 'npx --yes open-next@2 build'
 
 ---
 
@@ -3893,7 +3893,7 @@ public readonly buildCommand: string;
 
 Optional value used to install NextJS node dependencies.
 
-It defaults to 'npx --yes open-next@latest build'
+It defaults to 'npx --yes open-next@2 build'
 
 ---
 
@@ -4267,7 +4267,7 @@ public readonly buildCommand: string;
 
 Optional value used to install NextJS node dependencies.
 
-It defaults to 'npx --yes open-next@latest build'
+It defaults to 'npx --yes open-next@2 build'
 
 ---
 
@@ -4732,7 +4732,7 @@ public readonly buildCommand: string;
 
 Optional value used to install NextJS node dependencies.
 
-It defaults to 'npx --yes open-next@latest build'
+It defaults to 'npx --yes open-next@2 build'
 
 ---
 
@@ -5024,7 +5024,7 @@ public readonly buildCommand: string;
 
 Optional value used to install NextJS node dependencies.
 
-It defaults to 'npx --yes open-next@latest build'
+It defaults to 'npx --yes open-next@2 build'
 
 ---
 
@@ -5246,7 +5246,7 @@ public readonly buildCommand: string;
 
 Optional value used to install NextJS node dependencies.
 
-It defaults to 'npx --yes open-next@latest build'
+It defaults to 'npx --yes open-next@2 build'
 
 ---
 
@@ -5492,7 +5492,7 @@ public readonly buildCommand: string;
 
 Optional value used to install NextJS node dependencies.
 
-It defaults to 'npx --yes open-next@latest build'
+It defaults to 'npx --yes open-next@2 build'
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -1704,6 +1704,7 @@ Any object.
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextCacheDir">nextCacheDir</a></code> | <code>string</code> | Cache setup directory. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextImageFnDir">nextImageFnDir</a></code> | <code>string</code> | Contains function for processessing image requests. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextRevalidateFnDir">nextRevalidateFnDir</a></code> | <code>string</code> | Contains function for processing items from revalidation queue. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextServerFnDir">nextServerFnDir</a></code> | <code>string</code> | Contains server code and dependencies. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStaticDir">nextStaticDir</a></code> | <code>string</code> | Static files containing client-side code. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.projectRoot">projectRoot</a></code> | <code>string</code> | *No description.* |
@@ -1747,6 +1748,18 @@ public readonly nextImageFnDir: string;
 Contains function for processessing image requests.
 
 Should be arm64.
+
+---
+
+##### `nextRevalidateFnDir`<sup>Required</sup> <a name="nextRevalidateFnDir" id="cdk-nextjs-standalone.NextjsBuild.property.nextRevalidateFnDir"></a>
+
+```typescript
+public readonly nextRevalidateFnDir: string;
+```
+
+- *Type:* string
+
+Contains function for processing items from revalidation queue.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -4702,8 +4702,8 @@ const nextjsLambdaProps: NextjsLambdaProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
-| <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.cacheBucket">cacheBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The S3 bucket holding application cache. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built nextJS application. |
+| <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.staticAssetBucket">staticAssetBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Static asset bucket. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.lambda">lambda</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
 
 ---
@@ -4872,18 +4872,6 @@ Defaults to os.tmpdir().
 
 ---
 
-##### `cacheBucket`<sup>Required</sup> <a name="cacheBucket" id="cdk-nextjs-standalone.NextjsLambdaProps.property.cacheBucket"></a>
-
-```typescript
-public readonly cacheBucket: IBucket;
-```
-
-- *Type:* aws-cdk-lib.aws_s3.IBucket
-
-The S3 bucket holding application cache.
-
----
-
 ##### `nextBuild`<sup>Required</sup> <a name="nextBuild" id="cdk-nextjs-standalone.NextjsLambdaProps.property.nextBuild"></a>
 
 ```typescript
@@ -4893,6 +4881,20 @@ public readonly nextBuild: NextjsBuild;
 - *Type:* <a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a>
 
 Built nextJS application.
+
+---
+
+##### `staticAssetBucket`<sup>Required</sup> <a name="staticAssetBucket" id="cdk-nextjs-standalone.NextjsLambdaProps.property.staticAssetBucket"></a>
+
+```typescript
+public readonly staticAssetBucket: IBucket;
+```
+
+- *Type:* aws-cdk-lib.aws_s3.IBucket
+
+Static asset bucket.
+
+Function needs bucket to read from cache.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -4038,6 +4038,7 @@ const nextjsDefaultsProps: NextjsDefaultsProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.NextjsDefaultsProps.property.assetDeployment">assetDeployment</a></code> | <code>any</code> | Override static file deployment settings. |
+| <code><a href="#cdk-nextjs-standalone.NextjsDefaultsProps.property.cacheBucket">cacheBucket</a></code> | <code>any</code> | Override cache bucket. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDefaultsProps.property.distribution">distribution</a></code> | <code>any</code> | Override CloudFront distribution settings. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDefaultsProps.property.lambda">lambda</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override server lambda function settings. |
 
@@ -4052,6 +4053,18 @@ public readonly assetDeployment: any;
 - *Type:* any
 
 Override static file deployment settings.
+
+---
+
+##### `cacheBucket`<sup>Optional</sup> <a name="cacheBucket" id="cdk-nextjs-standalone.NextjsDefaultsProps.property.cacheBucket"></a>
+
+```typescript
+public readonly cacheBucket: any;
+```
+
+- *Type:* any
+
+Override cache bucket.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -2548,6 +2548,8 @@ The runtimes compatible with this Layer.
 
 Builds the system for revaluating Next.js resources. This includes a Lambda function handler and queue system.
 
+> [{@link https://github.com/serverless-stack/open-next/blob/main/README.md?plain=1#L65}]({@link https://github.com/serverless-stack/open-next/blob/main/README.md?plain=1#L65})
+
 #### Initializers <a name="Initializers" id="cdk-nextjs-standalone.NextjsRevalidation.Initializer"></a>
 
 ```typescript
@@ -3076,6 +3078,7 @@ const imageOptimizationProps: ImageOptimizationProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
+| <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The S3 bucket holding application images. |
 | <code><a href="#cdk-nextjs-standalone.ImageOptimizationProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | The `NextjsBuild` instance representing the built Nextjs application. |
@@ -3218,6 +3221,21 @@ If omitted, the layer will be created.
 
 ---
 
+##### `skipFullInvalidation`<sup>Optional</sup> <a name="skipFullInvalidation" id="cdk-nextjs-standalone.ImageOptimizationProps.property.skipFullInvalidation"></a>
+
+```typescript
+public readonly skipFullInvalidation: boolean;
+```
+
+- *Type:* boolean
+
+By default all CloudFront cache will be invalidated on deployment.
+
+This can be set to true to skip the full cache invalidation, which
+could be important for some users.
+
+---
+
 ##### `tempBuildDir`<sup>Optional</sup> <a name="tempBuildDir" id="cdk-nextjs-standalone.ImageOptimizationProps.property.tempBuildDir"></a>
 
 ```typescript
@@ -3339,6 +3357,7 @@ const nextjsAssetsDeploymentProps: NextjsAssetsDeploymentProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
+| <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Properties for the S3 bucket containing the NextJS assets. |
 | <code><a href="#cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | The `NextjsBuild` instance representing the built Nextjs application. |
@@ -3484,6 +3503,21 @@ public readonly sharpLayerArn: string;
 Optional arn for the sharp lambda layer.
 
 If omitted, the layer will be created.
+
+---
+
+##### `skipFullInvalidation`<sup>Optional</sup> <a name="skipFullInvalidation" id="cdk-nextjs-standalone.NextjsAssetsDeploymentProps.property.skipFullInvalidation"></a>
+
+```typescript
+public readonly skipFullInvalidation: boolean;
+```
+
+- *Type:* boolean
+
+By default all CloudFront cache will be invalidated on deployment.
+
+This can be set to true to skip the full cache invalidation, which
+could be important for some users.
 
 ---
 
@@ -3637,6 +3671,7 @@ const nextjsBaseProps: NextjsBaseProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBaseProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 
 ---
@@ -3776,6 +3811,21 @@ If omitted, the layer will be created.
 
 ---
 
+##### `skipFullInvalidation`<sup>Optional</sup> <a name="skipFullInvalidation" id="cdk-nextjs-standalone.NextjsBaseProps.property.skipFullInvalidation"></a>
+
+```typescript
+public readonly skipFullInvalidation: boolean;
+```
+
+- *Type:* boolean
+
+By default all CloudFront cache will be invalidated on deployment.
+
+This can be set to true to skip the full cache invalidation, which
+could be important for some users.
+
+---
+
 ##### `tempBuildDir`<sup>Optional</sup> <a name="tempBuildDir" id="cdk-nextjs-standalone.NextjsBaseProps.property.tempBuildDir"></a>
 
 ```typescript
@@ -3814,6 +3864,7 @@ const nextjsBuildProps: NextjsBuildProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 
 ---
@@ -3950,6 +4001,21 @@ public readonly sharpLayerArn: string;
 Optional arn for the sharp lambda layer.
 
 If omitted, the layer will be created.
+
+---
+
+##### `skipFullInvalidation`<sup>Optional</sup> <a name="skipFullInvalidation" id="cdk-nextjs-standalone.NextjsBuildProps.property.skipFullInvalidation"></a>
+
+```typescript
+public readonly skipFullInvalidation: boolean;
+```
+
+- *Type:* boolean
+
+By default all CloudFront cache will be invalidated on deployment.
+
+This can be set to true to skip the full cache invalidation, which
+could be important for some users.
 
 ---
 
@@ -4161,6 +4227,7 @@ const nextjsDistributionProps: NextjsDistributionProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
+| <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.imageOptFunction">imageOptFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | Lambda function to optimize images. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built NextJS app. |
@@ -4308,6 +4375,21 @@ public readonly sharpLayerArn: string;
 Optional arn for the sharp lambda layer.
 
 If omitted, the layer will be created.
+
+---
+
+##### `skipFullInvalidation`<sup>Optional</sup> <a name="skipFullInvalidation" id="cdk-nextjs-standalone.NextjsDistributionProps.property.skipFullInvalidation"></a>
+
+```typescript
+public readonly skipFullInvalidation: boolean;
+```
+
+- *Type:* boolean
+
+By default all CloudFront cache will be invalidated on deployment.
+
+This can be set to true to skip the full cache invalidation, which
+could be important for some users.
 
 ---
 
@@ -4618,6 +4700,7 @@ const nextjsLambdaProps: NextjsLambdaProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
+| <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.cacheBucket">cacheBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The S3 bucket holding application cache. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built nextJS application. |
@@ -4760,6 +4843,21 @@ If omitted, the layer will be created.
 
 ---
 
+##### `skipFullInvalidation`<sup>Optional</sup> <a name="skipFullInvalidation" id="cdk-nextjs-standalone.NextjsLambdaProps.property.skipFullInvalidation"></a>
+
+```typescript
+public readonly skipFullInvalidation: boolean;
+```
+
+- *Type:* boolean
+
+By default all CloudFront cache will be invalidated on deployment.
+
+This can be set to true to skip the full cache invalidation, which
+could be important for some users.
+
+---
+
 ##### `tempBuildDir`<sup>Optional</sup> <a name="tempBuildDir" id="cdk-nextjs-standalone.NextjsLambdaProps.property.tempBuildDir"></a>
 
 ```typescript
@@ -4895,6 +4993,7 @@ const nextjsProps: NextjsProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
+| <code><a href="#cdk-nextjs-standalone.NextjsProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.defaults">defaults</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsDefaultsProps">NextjsDefaultsProps</a></code> | Allows you to override defaults for the resources created by this construct. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.imageOptimizationBucket">imageOptimizationBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Optional S3 Bucket to use, defaults to assets bucket. |
@@ -5036,6 +5135,21 @@ If omitted, the layer will be created.
 
 ---
 
+##### `skipFullInvalidation`<sup>Optional</sup> <a name="skipFullInvalidation" id="cdk-nextjs-standalone.NextjsProps.property.skipFullInvalidation"></a>
+
+```typescript
+public readonly skipFullInvalidation: boolean;
+```
+
+- *Type:* boolean
+
+By default all CloudFront cache will be invalidated on deployment.
+
+This can be set to true to skip the full cache invalidation, which
+could be important for some users.
+
+---
+
 ##### `tempBuildDir`<sup>Optional</sup> <a name="tempBuildDir" id="cdk-nextjs-standalone.NextjsProps.property.tempBuildDir"></a>
 
 ```typescript
@@ -5098,6 +5212,7 @@ const nextjsS3EnvRewriterProps: NextjsS3EnvRewriterProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsS3EnvRewriterProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.NextjsS3EnvRewriterProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsS3EnvRewriterProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
+| <code><a href="#cdk-nextjs-standalone.NextjsS3EnvRewriterProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
 | <code><a href="#cdk-nextjs-standalone.NextjsS3EnvRewriterProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsS3EnvRewriterProps.property.replacementConfig">replacementConfig</a></code> | <code><a href="#cdk-nextjs-standalone.RewriteReplacementsConfig">RewriteReplacementsConfig</a></code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsS3EnvRewriterProps.property.s3Bucket">s3Bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | *No description.* |
@@ -5242,6 +5357,21 @@ If omitted, the layer will be created.
 
 ---
 
+##### `skipFullInvalidation`<sup>Optional</sup> <a name="skipFullInvalidation" id="cdk-nextjs-standalone.NextjsS3EnvRewriterProps.property.skipFullInvalidation"></a>
+
+```typescript
+public readonly skipFullInvalidation: boolean;
+```
+
+- *Type:* boolean
+
+By default all CloudFront cache will be invalidated on deployment.
+
+This can be set to true to skip the full cache invalidation, which
+could be important for some users.
+
+---
+
 ##### `tempBuildDir`<sup>Optional</sup> <a name="tempBuildDir" id="cdk-nextjs-standalone.NextjsS3EnvRewriterProps.property.tempBuildDir"></a>
 
 ```typescript
@@ -5330,6 +5460,7 @@ const revalidationProps: RevalidationProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
 | <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
 | <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | The `NextjsBuild` instance representing the built Nextjs application. |
 | <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.serverFunction">serverFunction</a></code> | <code><a href="#cdk-nextjs-standalone.NextJsLambda">NextJsLambda</a></code> | The main NextJS server handler lambda function. |
@@ -5469,6 +5600,21 @@ public readonly sharpLayerArn: string;
 Optional arn for the sharp lambda layer.
 
 If omitted, the layer will be created.
+
+---
+
+##### `skipFullInvalidation`<sup>Optional</sup> <a name="skipFullInvalidation" id="cdk-nextjs-standalone.RevalidationProps.property.skipFullInvalidation"></a>
+
+```typescript
+public readonly skipFullInvalidation: boolean;
+```
+
+- *Type:* boolean
+
+By default all CloudFront cache will be invalidated on deployment.
+
+This can be set to true to skip the full cache invalidation, which
+could be important for some users.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -1302,6 +1302,7 @@ Any object.
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.imageOptimizationLambdaFunctionUrl">imageOptimizationLambdaFunctionUrl</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionUrl</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.lambdaFunctionUrl">lambdaFunctionUrl</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionUrl</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built NextJS project output. |
+| <code><a href="#cdk-nextjs-standalone.Nextjs.property.revalidation">revalidation</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsRevalidation">NextjsRevalidation</a></code> | Revalidation handler and queue. |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.serverFunction">serverFunction</a></code> | <code><a href="#cdk-nextjs-standalone.NextJsLambda">NextJsLambda</a></code> | The main NextJS server handler lambda function. |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Where build-time assets for deployment are stored. |
 | <code><a href="#cdk-nextjs-standalone.Nextjs.property.configBucket">configBucket</a></code> | <code>aws-cdk-lib.aws_s3.Bucket</code> | *No description.* |
@@ -1405,6 +1406,18 @@ public readonly nextBuild: NextjsBuild;
 - *Type:* <a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a>
 
 Built NextJS project output.
+
+---
+
+##### `revalidation`<sup>Required</sup> <a name="revalidation" id="cdk-nextjs-standalone.Nextjs.property.revalidation"></a>
+
+```typescript
+public readonly revalidation: NextjsRevalidation;
+```
+
+- *Type:* <a href="#cdk-nextjs-standalone.NextjsRevalidation">NextjsRevalidation</a>
+
+Revalidation handler and queue.
 
 ---
 
@@ -1689,6 +1702,7 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextCacheDir">nextCacheDir</a></code> | <code>string</code> | Cache setup directory. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextImageFnDir">nextImageFnDir</a></code> | <code>string</code> | Contains function for processessing image requests. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextServerFnDir">nextServerFnDir</a></code> | <code>string</code> | Contains server code and dependencies. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStaticDir">nextStaticDir</a></code> | <code>string</code> | Static files containing client-side code. |
@@ -1707,6 +1721,18 @@ public readonly node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+##### `nextCacheDir`<sup>Required</sup> <a name="nextCacheDir" id="cdk-nextjs-standalone.NextjsBuild.property.nextCacheDir"></a>
+
+```typescript
+public readonly nextCacheDir: string;
+```
+
+- *Type:* string
+
+Cache setup directory.
 
 ---
 
@@ -2501,6 +2527,107 @@ public readonly compatibleRuntimes: Runtime[];
 - *Type:* aws-cdk-lib.aws_lambda.Runtime[]
 
 The runtimes compatible with this Layer.
+
+---
+
+
+### NextjsRevalidation <a name="NextjsRevalidation" id="cdk-nextjs-standalone.NextjsRevalidation"></a>
+
+Builds the system for revaluating Next.js resources. This includes a Lambda function handler and queue system.
+
+#### Initializers <a name="Initializers" id="cdk-nextjs-standalone.NextjsRevalidation.Initializer"></a>
+
+```typescript
+import { NextjsRevalidation } from 'cdk-nextjs-standalone'
+
+new NextjsRevalidation(scope: Construct, id: string, props: RevalidationProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.Initializer.parameter.props">props</a></code> | <code><a href="#cdk-nextjs-standalone.RevalidationProps">RevalidationProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="cdk-nextjs-standalone.NextjsRevalidation.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="cdk-nextjs-standalone.NextjsRevalidation.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="cdk-nextjs-standalone.NextjsRevalidation.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#cdk-nextjs-standalone.RevalidationProps">RevalidationProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.toString">toString</a></code> | Returns a string representation of this construct. |
+
+---
+
+##### `toString` <a name="toString" id="cdk-nextjs-standalone.NextjsRevalidation.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdk-nextjs-standalone.NextjsRevalidation.isConstruct"></a>
+
+```typescript
+import { NextjsRevalidation } from 'cdk-nextjs-standalone'
+
+NextjsRevalidation.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="cdk-nextjs-standalone.NextjsRevalidation.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="cdk-nextjs-standalone.NextjsRevalidation.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
 
 ---
 
@@ -4466,6 +4593,7 @@ const nextjsLambdaProps: NextjsLambdaProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
+| <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.cacheBucket">cacheBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The S3 bucket holding application cache. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | Built nextJS application. |
 | <code><a href="#cdk-nextjs-standalone.NextjsLambdaProps.property.lambda">lambda</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
 
@@ -4617,6 +4745,18 @@ public readonly tempBuildDir: string;
 Directory to store temporary build files in.
 
 Defaults to os.tmpdir().
+
+---
+
+##### `cacheBucket`<sup>Required</sup> <a name="cacheBucket" id="cdk-nextjs-standalone.NextjsLambdaProps.property.cacheBucket"></a>
+
+```typescript
+public readonly cacheBucket: IBucket;
+```
+
+- *Type:* aws-cdk-lib.aws_s3.IBucket
+
+The S3 bucket holding application cache.
 
 ---
 
@@ -5137,6 +5277,222 @@ public readonly debug: boolean;
 ```
 
 - *Type:* boolean
+
+---
+
+### RevalidationProps <a name="RevalidationProps" id="cdk-nextjs-standalone.RevalidationProps"></a>
+
+#### Initializer <a name="Initializer" id="cdk-nextjs-standalone.RevalidationProps.Initializer"></a>
+
+```typescript
+import { RevalidationProps } from 'cdk-nextjs-standalone'
+
+const revalidationProps: RevalidationProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.nextjsPath">nextjsPath</a></code> | <code>string</code> | Relative path to the directory where the NextJS project is located. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.buildCommand">buildCommand</a></code> | <code>string</code> | Optional value used to install NextJS node dependencies. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.buildPath">buildPath</a></code> | <code>string</code> | The directory to execute `npm run build` from. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.compressionLevel">compressionLevel</a></code> | <code>number</code> | 0 - no compression, fastest 9 - maximum compression, slowest. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | Custom environment variables to pass to the NextJS build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.isPlaceholder">isPlaceholder</a></code> | <code>boolean</code> | Skip building app and deploy a placeholder. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.nodeEnv">nodeEnv</a></code> | <code>string</code> | Optional value for NODE_ENV during build and runtime. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.projectRoot">projectRoot</a></code> | <code>string</code> | Root of your project, if different from `nextjsPath`. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.sharpLayerArn">sharpLayerArn</a></code> | <code>string</code> | Optional arn for the sharp lambda layer. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | The `NextjsBuild` instance representing the built Nextjs application. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.serverFunction">serverFunction</a></code> | <code><a href="#cdk-nextjs-standalone.NextJsLambda">NextJsLambda</a></code> | The main NextJS server handler lambda function. |
+| <code><a href="#cdk-nextjs-standalone.RevalidationProps.property.lambdaOptions">lambdaOptions</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
+
+---
+
+##### `nextjsPath`<sup>Required</sup> <a name="nextjsPath" id="cdk-nextjs-standalone.RevalidationProps.property.nextjsPath"></a>
+
+```typescript
+public readonly nextjsPath: string;
+```
+
+- *Type:* string
+
+Relative path to the directory where the NextJS project is located.
+
+Can be the root of your project (`.`) or a subdirectory (`packages/web`).
+
+---
+
+##### `buildCommand`<sup>Optional</sup> <a name="buildCommand" id="cdk-nextjs-standalone.RevalidationProps.property.buildCommand"></a>
+
+```typescript
+public readonly buildCommand: string;
+```
+
+- *Type:* string
+
+Optional value used to install NextJS node dependencies.
+
+It defaults to 'npx --yes open-next@latest build'
+
+---
+
+##### `buildPath`<sup>Optional</sup> <a name="buildPath" id="cdk-nextjs-standalone.RevalidationProps.property.buildPath"></a>
+
+```typescript
+public readonly buildPath: string;
+```
+
+- *Type:* string
+
+The directory to execute `npm run build` from.
+
+By default, it is `nextjsPath`.
+Can be overridden, particularly useful for monorepos where `build` is expected to run
+at the root of the project.
+
+---
+
+##### `compressionLevel`<sup>Optional</sup> <a name="compressionLevel" id="cdk-nextjs-standalone.RevalidationProps.property.compressionLevel"></a>
+
+```typescript
+public readonly compressionLevel: number;
+```
+
+- *Type:* number
+- *Default:* 1
+
+0 - no compression, fastest 9 - maximum compression, slowest.
+
+---
+
+##### `environment`<sup>Optional</sup> <a name="environment" id="cdk-nextjs-standalone.RevalidationProps.property.environment"></a>
+
+```typescript
+public readonly environment: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Custom environment variables to pass to the NextJS build and runtime.
+
+---
+
+##### `isPlaceholder`<sup>Optional</sup> <a name="isPlaceholder" id="cdk-nextjs-standalone.RevalidationProps.property.isPlaceholder"></a>
+
+```typescript
+public readonly isPlaceholder: boolean;
+```
+
+- *Type:* boolean
+
+Skip building app and deploy a placeholder.
+
+Useful when using `next dev` for local development.
+
+---
+
+##### `nodeEnv`<sup>Optional</sup> <a name="nodeEnv" id="cdk-nextjs-standalone.RevalidationProps.property.nodeEnv"></a>
+
+```typescript
+public readonly nodeEnv: string;
+```
+
+- *Type:* string
+
+Optional value for NODE_ENV during build and runtime.
+
+---
+
+##### `projectRoot`<sup>Optional</sup> <a name="projectRoot" id="cdk-nextjs-standalone.RevalidationProps.property.projectRoot"></a>
+
+```typescript
+public readonly projectRoot: string;
+```
+
+- *Type:* string
+
+Root of your project, if different from `nextjsPath`.
+
+Defaults to current working directory.
+
+---
+
+##### `quiet`<sup>Optional</sup> <a name="quiet" id="cdk-nextjs-standalone.RevalidationProps.property.quiet"></a>
+
+```typescript
+public readonly quiet: boolean;
+```
+
+- *Type:* boolean
+
+Less build output.
+
+---
+
+##### `sharpLayerArn`<sup>Optional</sup> <a name="sharpLayerArn" id="cdk-nextjs-standalone.RevalidationProps.property.sharpLayerArn"></a>
+
+```typescript
+public readonly sharpLayerArn: string;
+```
+
+- *Type:* string
+
+Optional arn for the sharp lambda layer.
+
+If omitted, the layer will be created.
+
+---
+
+##### `tempBuildDir`<sup>Optional</sup> <a name="tempBuildDir" id="cdk-nextjs-standalone.RevalidationProps.property.tempBuildDir"></a>
+
+```typescript
+public readonly tempBuildDir: string;
+```
+
+- *Type:* string
+
+Directory to store temporary build files in.
+
+Defaults to os.tmpdir().
+
+---
+
+##### `nextBuild`<sup>Required</sup> <a name="nextBuild" id="cdk-nextjs-standalone.RevalidationProps.property.nextBuild"></a>
+
+```typescript
+public readonly nextBuild: NextjsBuild;
+```
+
+- *Type:* <a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a>
+
+The `NextjsBuild` instance representing the built Nextjs application.
+
+---
+
+##### `serverFunction`<sup>Required</sup> <a name="serverFunction" id="cdk-nextjs-standalone.RevalidationProps.property.serverFunction"></a>
+
+```typescript
+public readonly serverFunction: NextJsLambda;
+```
+
+- *Type:* <a href="#cdk-nextjs-standalone.NextJsLambda">NextJsLambda</a>
+
+The main NextJS server handler lambda function.
+
+---
+
+##### `lambdaOptions`<sup>Optional</sup> <a name="lambdaOptions" id="cdk-nextjs-standalone.RevalidationProps.property.lambdaOptions"></a>
+
+```typescript
+public readonly lambdaOptions: FunctionOptions;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.FunctionOptions
+
+Override function properties.
 
 ---
 

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -48,6 +48,8 @@ export class ImageOptimizationLambda extends Function {
       : Code.fromAsset(props.nextBuild.nextImageFnDir);
 
     super(scope, id, {
+      // open-next image-optimization-function
+      // see: https://github.com/serverless-stack/open-next/blob/274d446ed7e940cfbe7ce05a21108f4c854ee37a/README.md?plain=1#L66
       code,
       handler: 'index.handler',
       runtime: LAMBDA_RUNTIME,

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -43,8 +43,8 @@ export class ImageOptimizationLambda extends Function {
 
     const code = isPlaceholder
       ? Code.fromInline(
-        "module.exports.handler = async () => { return { statusCode: 200, body: 'SST placeholder site' } }"
-      )
+          "module.exports.handler = async () => { return { statusCode: 200, body: 'cdk-nextjs placeholder site' } }"
+        )
       : Code.fromAsset(props.nextBuild.nextImageFnDir);
 
     super(scope, id, {

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -4,7 +4,7 @@ import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Architecture, Code, Function, FunctionOptions } from 'aws-cdk-lib/aws-lambda';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
-import { LAMBDA_RUNTIME } from './constants';
+import { LAMBDA_RUNTIME, DEFAULT_LAMBA_MEMORY } from './constants';
 import { NextjsBaseProps } from './NextjsBase';
 import type { NextjsBuild } from './NextjsBuild';
 
@@ -59,7 +59,7 @@ export class ImageOptimizationLambda extends Function {
       functionName: Stack.of(scope).region !== 'us-east-1' ? PhysicalName.GENERATE_IF_NEEDED : undefined,
       ...lambdaOptions,
       // defaults
-      memorySize: lambdaOptions?.memorySize || 1024,
+      memorySize: lambdaOptions?.memorySize || DEFAULT_LAMBA_MEMORY,
       timeout: lambdaOptions?.timeout ?? Duration.seconds(10),
       environment: {
         BUCKET_NAME: bucket.bucketName,

--- a/src/ImageOptimizationLambda.ts
+++ b/src/ImageOptimizationLambda.ts
@@ -52,6 +52,7 @@ export class ImageOptimizationLambda extends Function {
       handler: 'index.handler',
       runtime: LAMBDA_RUNTIME,
       architecture: Architecture.ARM_64,
+      description: 'Next.js Image Optimization Function',
       // prevents "Resolution error: Cannot use resource in a cross-environment
       // fashion, the resource's physical name must be explicit set or use
       // PhysicalName.GENERATE_IF_NEEDED."

--- a/src/NextjsBase.ts
+++ b/src/NextjsBase.ts
@@ -51,7 +51,7 @@ export interface NextjsBaseProps {
 
   /**
    * Optional value used to install NextJS node dependencies.
-   * It defaults to 'npx --yes open-next@1 build'
+   * It defaults to 'npx --yes open-next@2 build'
    */
   readonly buildCommand?: string;
 

--- a/src/NextjsBase.ts
+++ b/src/NextjsBase.ts
@@ -72,6 +72,13 @@ export interface NextjsBaseProps {
    * If omitted, the layer will be created.
    */
   readonly sharpLayerArn?: string;
+
+  /**
+   * By default all CloudFront cache will be invalidated on deployment.
+   * This can be set to true to skip the full cache invalidation, which
+   * could be important for some users.
+   */
+  readonly skipFullInvalidation?: boolean;
 }
 
 ///// stuff below taken from https://github.com/serverless-stack/sst/blob/8d377e941467ced81d8cc31ee67d5a06550f04d4/packages/resources/src/BaseSite.ts

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -9,6 +9,7 @@ import { CompressionLevel, NextjsBaseProps } from './NextjsBase';
 const NEXTJS_BUILD_DIR = '.open-next';
 const NEXTJS_STATIC_DIR = 'assets';
 const NEXTJS_BUILD_MIDDLEWARE_FN_DIR = 'middleware-function';
+const NEXTJS_BUILD_REVALIDATE_FN_DIR = 'revalidation-function';
 const NEXTJS_BUILD_IMAGE_FN_DIR = 'image-optimization-function';
 const NEXTJS_BUILD_SERVER_FN_DIR = 'server-function';
 
@@ -34,6 +35,10 @@ export class NextjsBuild extends Construct {
    * Should be arm64.
    */
   public nextImageFnDir: string;
+  /**
+   * Contains function for processing items from revalidation queue.
+   */
+  public nextRevalidateFnDir: string;
   /**
    * Static files containing client-side code.
    */
@@ -66,6 +71,7 @@ export class NextjsBuild extends Construct {
     // our outputs
     this.nextStaticDir = this._getNextStaticDir();
     this.nextImageFnDir = this._getOutputDir(NEXTJS_BUILD_IMAGE_FN_DIR);
+    this.nextRevalidateFnDir = this._getOutputDir(NEXTJS_BUILD_REVALIDATE_FN_DIR);
     this.nextServerFnDir = this._getOutputDir(NEXTJS_BUILD_SERVER_FN_DIR);
     this.nextMiddlewareFnDir = this._getOutputDir(NEXTJS_BUILD_MIDDLEWARE_FN_DIR, true);
     // this.nextDir = this._getNextDir();

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -100,7 +100,7 @@ export class NextjsBuild extends Construct {
     };
 
     const buildPath = this.props.buildPath ?? nextjsPath;
-    const buildCommand = this.props.buildCommand ?? 'npx --yes open-next@1 build';
+    const buildCommand = this.props.buildCommand ?? 'npx --yes open-next@2 build';
     // run build
     console.debug(`├ Running "${buildCommand}" in`, buildPath);
     const cmdParts = buildCommand.split(/\s+/);

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -8,6 +8,7 @@ import { CompressionLevel, NextjsBaseProps } from './NextjsBase';
 
 const NEXTJS_BUILD_DIR = '.open-next';
 const NEXTJS_STATIC_DIR = 'assets';
+const NEXTJS_CACHE_DIR = 'cache';
 const NEXTJS_BUILD_MIDDLEWARE_FN_DIR = 'middleware-function';
 const NEXTJS_BUILD_REVALIDATE_FN_DIR = 'revalidation-function';
 const NEXTJS_BUILD_IMAGE_FN_DIR = 'image-optimization-function';
@@ -43,6 +44,10 @@ export class NextjsBuild extends Construct {
    * Static files containing client-side code.
    */
   public nextStaticDir: string;
+  /**
+   * Cache directory for generated data.
+   */
+  public nextCacheDir: string;
 
   public props: NextjsBuildProps;
 
@@ -70,6 +75,7 @@ export class NextjsBuild extends Construct {
 
     // our outputs
     this.nextStaticDir = this._getNextStaticDir();
+    this.nextCacheDir = this._getNextCacheDir();
     this.nextImageFnDir = this._getOutputDir(NEXTJS_BUILD_IMAGE_FN_DIR);
     this.nextRevalidateFnDir = this._getOutputDir(NEXTJS_BUILD_REVALIDATE_FN_DIR);
     this.nextServerFnDir = this._getOutputDir(NEXTJS_BUILD_SERVER_FN_DIR);
@@ -160,6 +166,11 @@ export class NextjsBuild extends Construct {
   // contains static files
   private _getNextStaticDir() {
     return path.join(this._getNextBuildDir(), NEXTJS_STATIC_DIR);
+  }
+
+  // contains cache files
+  private _getNextCacheDir() {
+    return path.join(this._getNextBuildDir(), NEXTJS_CACHE_DIR);
   }
 }
 

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -378,17 +378,6 @@ export class NextjsDistribution extends Construct {
       },
     ];
 
-    // default handler for requests that don't match any other path:
-    //   - try lambda handler first (/some-page, etc...)
-    //   - if 403, fall back to S3
-    //   - if 404, fall back to lambda handler
-    //   - if 503, fall back to lambda handler
-    const fallbackOriginGroup = new origins.OriginGroup({
-      primaryOrigin: serverFunctionOrigin,
-      fallbackOrigin: s3Origin,
-      fallbackStatusCodes: [403, 404, 503],
-    });
-
     const lambdaCachePolicy = cachePolicies?.lambdaCachePolicy ?? this.createCloudFrontLambdaCachePolicy();
 
     // requests for static objects
@@ -461,15 +450,18 @@ export class NextjsDistribution extends Construct {
       domainNames,
       certificate: this.certificate,
       defaultBehavior: {
-        origin: fallbackOriginGroup, // try S3 first, then lambda
+        origin: new origins.HttpOrigin(Fn.parseDomainName(fnUrl.url), {
+          // todo: decide what an appropriate way to allow this to be configured is
+          readTimeout: Duration.seconds(10),
+        }),
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         compress: true,
-
         // what goes here? static or lambda?
         cachePolicy: lambdaCachePolicy,
         originRequestPolicy: fallbackOriginRequestPolicy,
-
         edgeLambdas: lambdaOriginEdgeFns,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+        cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
       },
 
       additionalBehaviors: {

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -379,13 +379,12 @@ export class NextjsDistribution extends Construct {
     ];
 
     // default handler for requests that don't match any other path:
-    //   - try lambda handler first (/some-page, etc...)
-    //   - if 403, fall back to S3
-    //   - if 404, fall back to lambda handler
-    //   - if 503, fall back to lambda handler
+    //   - try S3 bucket first
+    //   - if 403, 404, or 503 fall back to Lambda handler
+    // see discussion here: https://github.com/jetbridge/cdk-nextjs/pull/125#discussion_r1279212678
     const fallbackOriginGroup = new origins.OriginGroup({
-      primaryOrigin: serverFunctionOrigin,
-      fallbackOrigin: s3Origin,
+      primaryOrigin: s3Origin,
+      fallbackOrigin: serverFunctionOrigin,
       fallbackStatusCodes: [403, 404, 503],
     });
 

--- a/src/NextjsLambda.ts
+++ b/src/NextjsLambda.ts
@@ -24,7 +24,7 @@ function getEnvironment(props: NextjsLambdaProps): { [name: string]: string } {
     ...(props.nodeEnv ? { NODE_ENV: props.nodeEnv } : {}),
     ...{
       CACHE_BUCKET_NAME: props.cacheBucket?.bucketName || '',
-      CACHE_BUCKET_KEY_PREFIX: '_cache',
+      // Note we don't need a CACHE_BUCKET_KEY_PREFIX because we're using a separate bucket for cache
       // @see: https://github.com/serverless-stack/sst/blob/master/packages/sst/src/constructs/NextjsSite.ts#L158
       // TODO: refactor this or pass in the region
       // CACHE_BUCKET_REGION: Stack.of(this).region,

--- a/src/NextjsLambda.ts
+++ b/src/NextjsLambda.ts
@@ -92,12 +92,15 @@ export class NextJsLambda extends Construct {
       runtime: LAMBDA_RUNTIME,
       handler: path.join('index.handler'),
       code,
-      environment,
       // prevents "Resolution error: Cannot use resource in a cross-environment
       // fashion, the resource's physical name must be explicit set or use
       // PhysicalName.GENERATE_IF_NEEDED."
       functionName: Stack.of(this).region !== 'us-east-1' ? PhysicalName.GENERATE_IF_NEEDED : undefined,
       ...functionOptions,
+      // `environment` needs to go after `functionOptions` b/c if
+      // `functionOptions.environment` is defined, it will override
+      // CACHE_* environment variables which are required
+      environment,
     });
     this.lambdaFunction = fn;
 

--- a/src/NextjsRevalidation.ts
+++ b/src/NextjsRevalidation.ts
@@ -37,7 +37,7 @@ export class NextjsRevalidation extends Construct {
       ? Code.fromInline(
           "module.exports.handler = async () => { return { statusCode: 200, body: 'cdk-nextjs placeholder site' } }"
         )
-      : Code.fromAsset(props.nextBuild.nextImageFnDir);
+      : Code.fromAsset(props.nextBuild.nextRevalidateFnDir);
 
     const queue = new Queue(this, 'RevalidationQueue', {
       fifo: true,

--- a/src/NextjsRevalidation.ts
+++ b/src/NextjsRevalidation.ts
@@ -7,7 +7,7 @@ import { NextjsBaseProps } from './NextjsBase';
 import { NextjsBuild } from './NextjsBuild';
 import { NextJsLambda } from './NextjsLambda';
 
-export interface RevaluationProps extends NextjsBaseProps {
+export interface RevalidationProps extends NextjsBaseProps {
   /**
    * Override function properties.
    */
@@ -27,15 +27,15 @@ export interface RevaluationProps extends NextjsBaseProps {
 /**
  * Builds the system for revaluating Next.js resources. This includes a Lambda function handler and queue system.
  */
-export class NextjsRevaluation extends Construct {
-  constructor(scope: Construct, id: string, props: RevaluationProps) {
+export class NextjsRevalidation extends Construct {
+  constructor(scope: Construct, id: string, props: RevalidationProps) {
     super(scope, id);
 
     if (!props.nextBuild) return;
 
     const code = props.isPlaceholder
       ? Code.fromInline(
-          "module.exports.handler = async () => { return { statusCode: 200, body: 'SST placeholder site' } }"
+          "module.exports.handler = async () => { return { statusCode: 200, body: 'cdk-nextjs placeholder site' } }"
         )
       : Code.fromAsset(props.nextBuild.nextImageFnDir);
 
@@ -44,13 +44,11 @@ export class NextjsRevaluation extends Construct {
       receiveMessageWaitTime: Duration.seconds(20),
     });
     const consumer = new Function(this, 'RevalidationFunction', {
-      description: 'Next.js revalidator',
+      description: 'Next.js revalidation function',
       handler: 'index.handler',
       code,
       runtime: Runtime.NODEJS_18_X,
       timeout: Duration.seconds(30),
-      // This, I think, is supposed to be the VPC or VPC Subnet config (https://github.com/serverless-stack/sst/blob/master/packages/sst/src/constructs/NextjsSite.ts#L59C5-L59C17)
-      // ...this.revalidation,
     });
     consumer.addEventSource(new SqsEventSource(queue, { batchSize: 5 }));
 

--- a/src/NextjsRevalidation.ts
+++ b/src/NextjsRevalidation.ts
@@ -26,6 +26,9 @@ export interface RevalidationProps extends NextjsBaseProps {
 
 /**
  * Builds the system for revaluating Next.js resources. This includes a Lambda function handler and queue system.
+ *
+ * @see {@link https://github.com/serverless-stack/open-next/blob/main/README.md?plain=1#L65}
+ *
  */
 export class NextjsRevalidation extends Construct {
   constructor(scope: Construct, id: string, props: RevalidationProps) {
@@ -44,6 +47,8 @@ export class NextjsRevalidation extends Construct {
     const consumer = new Function(this, 'RevalidationFunction', {
       description: 'Next.js revalidation function',
       handler: 'index.handler',
+      // open-next revalidation-function
+      // see: https://github.com/serverless-stack/open-next/blob/274d446ed7e940cfbe7ce05a21108f4c854ee37a/README.md?plain=1#L65
       code,
       runtime: Runtime.NODEJS_18_X,
       timeout: Duration.seconds(30),

--- a/src/NextjsRevalidation.ts
+++ b/src/NextjsRevalidation.ts
@@ -25,7 +25,7 @@ export interface RevalidationProps extends NextjsBaseProps {
 }
 
 /**
- * Builds the system for revaluating Next.js resources. This includes a Lambda function handler and queue system.
+ * Builds the system for revalidating Next.js resources. This includes a Lambda function handler and queue system.
  *
  * @see {@link https://github.com/serverless-stack/open-next/blob/main/README.md?plain=1#L65}
  *

--- a/src/NextjsRevalidation.ts
+++ b/src/NextjsRevalidation.ts
@@ -31,8 +31,6 @@ export class NextjsRevalidation extends Construct {
   constructor(scope: Construct, id: string, props: RevalidationProps) {
     super(scope, id);
 
-    if (!props.nextBuild) return;
-
     const code = props.isPlaceholder
       ? Code.fromInline(
           "module.exports.handler = async () => { return { statusCode: 200, body: 'cdk-nextjs placeholder site' } }"
@@ -56,6 +54,6 @@ export class NextjsRevalidation extends Construct {
     const server = props.serverFunction.lambdaFunction;
     server?.addEnvironment('REVALIDATION_QUEUE_URL', queue.queueUrl);
     server?.addEnvironment('REVALIDATION_QUEUE_REGION', Stack.of(this).region);
-    queue.grantSendMessages(server?.role!);
+    queue.grantSendMessages(server);
   }
 }

--- a/src/NextjsRevaluation.ts
+++ b/src/NextjsRevaluation.ts
@@ -1,0 +1,63 @@
+import { Duration, Stack } from 'aws-cdk-lib';
+import { Code, Function, FunctionOptions, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
+import { Construct } from 'constructs';
+import { NextjsBaseProps } from './NextjsBase';
+import { NextjsBuild } from './NextjsBuild';
+import { NextJsLambda } from './NextjsLambda';
+
+export interface RevaluationProps extends NextjsBaseProps {
+  /**
+   * Override function properties.
+   */
+  readonly lambdaOptions?: FunctionOptions;
+
+  /**
+   * The `NextjsBuild` instance representing the built Nextjs application.
+   */
+  readonly nextBuild: NextjsBuild;
+
+  /**
+   * The main NextJS server handler lambda function.
+   */
+  readonly serverFunction: NextJsLambda;
+}
+
+/**
+ * Builds the system for revaluating Next.js resources. This includes a Lambda function handler and queue system.
+ */
+export class NextjsRevaluation extends Construct {
+  constructor(scope: Construct, id: string, props: RevaluationProps) {
+    super(scope, id);
+
+    if (!props.nextBuild) return;
+
+    const code = props.isPlaceholder
+      ? Code.fromInline(
+          "module.exports.handler = async () => { return { statusCode: 200, body: 'SST placeholder site' } }"
+        )
+      : Code.fromAsset(props.nextBuild.nextImageFnDir);
+
+    const queue = new Queue(this, 'RevalidationQueue', {
+      fifo: true,
+      receiveMessageWaitTime: Duration.seconds(20),
+    });
+    const consumer = new Function(this, 'RevalidationFunction', {
+      description: 'Next.js revalidator',
+      handler: 'index.handler',
+      code,
+      runtime: Runtime.NODEJS_18_X,
+      timeout: Duration.seconds(30),
+      // This, I think, is supposed to be the VPC or VPC Subnet config (https://github.com/serverless-stack/sst/blob/master/packages/sst/src/constructs/NextjsSite.ts#L59C5-L59C17)
+      // ...this.revalidation,
+    });
+    consumer.addEventSource(new SqsEventSource(queue, { batchSize: 5 }));
+
+    // Allow server to send messages to the queue
+    const server = props.serverFunction.lambdaFunction;
+    server?.addEnvironment('REVALIDATION_QUEUE_URL', queue.queueUrl);
+    server?.addEnvironment('REVALIDATION_QUEUE_REGION', Stack.of(this).region);
+    queue.grantSendMessages(server?.role!);
+  }
+}

--- a/src/NextjsS3EnvRewriter.ts
+++ b/src/NextjsS3EnvRewriter.ts
@@ -9,6 +9,7 @@ import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import * as cr from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { bundleFunction } from './BundleFunction';
+import { DEFAULT_LAMBA_MEMORY } from './constants';
 import { NextjsBaseProps } from './NextjsBase';
 import { makeTokenPlaceholder } from './NextjsBuild';
 
@@ -73,7 +74,7 @@ export class NextjsS3EnvRewriter extends Construct {
     // rewriter lambda function
     const rewriteFn = new lambda.Function(this, 'RewriteOnEventHandler', {
       runtime: Runtime.NODEJS_16_X,
-      memorySize: 1024,
+      memorySize: DEFAULT_LAMBA_MEMORY,
       timeout: Duration.minutes(5),
       handler: 'S3EnvRewriter.handler',
       code: lambda.Code.fromAsset(handlerDir),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,5 @@ export const LAMBDA_RUNTIME = Runtime.NODEJS_18_X;
  * @see {@link https://dev.to/dashbird/4-tips-for-aws-lambda-optimization-for-production-3if1}
  */
 export const DEFAULT_LAMBA_MEMORY = 1536;
+
+export const CACHE_BUCKET_KEY_PREFIX = '_cache';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,4 +6,8 @@ export const DEFAULT_STATIC_STALE_WHILE_REVALIDATE = Duration.days(1).toSeconds(
 
 export const LAMBDA_RUNTIME = Runtime.NODEJS_18_X;
 
+/**
+ * 1536mb costs 1.5x but runs twice as fast for most scenarios.
+ * @see {@link https://dev.to/dashbird/4-tips-for-aws-lambda-optimization-for-production-3if1}
+ */
 export const DEFAULT_LAMBA_MEMORY = 1536;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,3 +5,5 @@ export const DEFAULT_STATIC_MAX_AGE = Duration.days(30).toSeconds();
 export const DEFAULT_STATIC_STALE_WHILE_REVALIDATE = Duration.days(1).toSeconds();
 
 export const LAMBDA_RUNTIME = Runtime.NODEJS_18_X;
+
+export const DEFAULT_LAMBA_MEMORY = 1536;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
   NextjsAssetsDeploymentProps,
   NextjsAssetsCachePolicyProps,
 } from './NextjsAssetsDeployment';
+export { NextjsRevaluation, RevaluationProps } from './NextjsRevaluation';
 export { NextjsBuild, NextjsBuildProps, CreateArchiveArgs } from './NextjsBuild';
 export { EnvironmentVars, NextJsLambda, NextjsLambdaProps } from './NextjsLambda';
 export { ImageOptimizationLambda, ImageOptimizationProps } from './ImageOptimizationLambda';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export {
   NextjsAssetsDeploymentProps,
   NextjsAssetsCachePolicyProps,
 } from './NextjsAssetsDeployment';
-export { NextjsRevaluation, RevaluationProps } from './NextjsRevaluation';
+export { NextjsRevalidation, RevalidationProps } from './NextjsRevalidation';
 export { NextjsBuild, NextjsBuildProps, CreateArchiveArgs } from './NextjsBuild';
 export { EnvironmentVars, NextJsLambda, NextjsLambdaProps } from './NextjsLambda';
 export { ImageOptimizationLambda, ImageOptimizationProps } from './ImageOptimizationLambda';


### PR DESCRIPTION
See: https://github.com/jetbridge/cdk-nextjs/issues/119

Updates the server handler to include cache bucket configuration, **which is likely not correct as I'm just using the static asset bucket temporarily**. I need to look at how SST does this and what the spirit of this should be, e.g. if a separate bucket would be more appropriate, a folder, etc.

This also adds the ISR handling logic. I haven't actually tested this yet (am not 100% sure how to).

**This is a WIP**.

Fixes #119 

## TODO

1. ~~Confirm if we should make a new bucket for cache or use an existing bucket~~
2. ~~Confirm permissions appropriate for this bucket between nextjs server and the bucket~~
3. Confirm if ISR feature is working and what else may be needed
4. ~~Make sure I didn't break anything along the way~~
5. I'd like to add descriptions to other functions