### PR TITLE
fix: pin major version of open-next to 1

### DIFF
--- a/src/NextjsBase.ts
+++ b/src/NextjsBase.ts
@@ -51,7 +51,7 @@ export interface NextjsBaseProps {
 
   /**
    * Optional value used to install NextJS node dependencies.
-   * It defaults to 'npx --yes open-next@latest build'
+   * It defaults to 'npx --yes open-next@1 build'
    */
   readonly buildCommand?: string;
 

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -100,7 +100,7 @@ export class NextjsBuild extends Construct {
     };
 
     const buildPath = this.props.buildPath ?? nextjsPath;
-    const buildCommand = this.props.buildCommand ?? 'npx --yes open-next build';
+    const buildCommand = this.props.buildCommand ?? 'npx --yes open-next@1 build';
     // run build
     console.debug(`├ Running "${buildCommand}" in`, buildPath);
     const cmdParts = buildCommand.split(/\s+/);


### PR DESCRIPTION
Currently, `cdk-nextjs` is not compatible with the latest v2+ version of `open-next`. Work is being done to update the project to be compatible, but for now we'll make sure new users coming to `cdk-nextjs` for the first time are to deploy a working Next.js site.

see: https://github.com/jetbridge/cdk-nextjs/issues/126

Fixes #