### PR TITLE
fix: server actions by removing origin group

### DIFF
--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -3,16 +3,17 @@ import { Token } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as spawn from 'cross-spawn';
 import * as fs from 'fs-extra';
+import {
+  NEXTJS_BUILD_DIR,
+  NEXTJS_BUILD_IMAGE_FN_DIR,
+  NEXTJS_BUILD_MIDDLEWARE_FN_DIR,
+  NEXTJS_BUILD_REVALIDATE_FN_DIR,
+  NEXTJS_BUILD_SERVER_FN_DIR,
+  NEXTJS_CACHE_DIR,
+  NEXTJS_STATIC_DIR,
+} from './constants';
 import { listDirectory } from './NextjsAssetsDeployment';
 import { CompressionLevel, NextjsBaseProps } from './NextjsBase';
-
-const NEXTJS_BUILD_DIR = '.open-next';
-const NEXTJS_STATIC_DIR = 'assets';
-const NEXTJS_CACHE_DIR = 'cache';
-const NEXTJS_BUILD_MIDDLEWARE_FN_DIR = 'middleware-function';
-const NEXTJS_BUILD_REVALIDATE_FN_DIR = 'revalidation-function';
-const NEXTJS_BUILD_IMAGE_FN_DIR = 'image-optimization-function';
-const NEXTJS_BUILD_SERVER_FN_DIR = 'server-function';
 
 export interface NextjsBuildProps extends NextjsBaseProps {}
 

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -169,9 +169,9 @@ export class NextjsDistribution extends Construct {
   };
 
   /**
-   * The default CloudFront cache policy properties for the Lambda server handler.
+   * The default CloudFront cache policy properties for dynamic requests to server handler.
    */
-  public static lambdaCachePolicyProps: cloudfront.CachePolicyProps = {
+  public static dynamicCachePolicyProps: cloudfront.CachePolicyProps = {
     queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
     headerBehavior: cloudfront.CacheHeaderBehavior.allowList('rsc', 'next-router-prefetch', 'next-router-state-tree'),
     cookieBehavior: cloudfront.CacheCookieBehavior.all(),
@@ -180,17 +180,17 @@ export class NextjsDistribution extends Construct {
     minTtl: Duration.seconds(0),
     enableAcceptEncodingBrotli: true,
     enableAcceptEncodingGzip: true,
-    comment: 'Nextjs Lambda Default Cache Policy',
+    comment: 'Nextjs Dynamic Default Cache Policy',
   };
 
   /**
    * The default CloudFront lambda origin request policy.
    */
-  public static lambdaOriginRequestPolicyProps: cloudfront.OriginRequestPolicyProps = {
+  public static dynamicOriginRequestPolicyProps: cloudfront.OriginRequestPolicyProps = {
     cookieBehavior: cloudfront.OriginRequestCookieBehavior.all(),
     queryStringBehavior: cloudfront.OriginRequestQueryStringBehavior.all(),
     headerBehavior: cloudfront.OriginRequestHeaderBehavior.all(), // can't include host
-    comment: 'Nextjs Lambda Origin Request Policy',
+    comment: 'Nextjs Dynamic Origin Request Policy',
   };
 
   public static fallbackOriginRequestPolicyProps: cloudfront.OriginRequestPolicyProps = {
@@ -250,9 +250,12 @@ export class NextjsDistribution extends Construct {
     this.certificate = this.createCertificate();
 
     // Create CloudFront
-    this.distribution = this.props.isPlaceholder
-      ? this.createCloudFrontDistributionForStub()
-      : this.createCloudFrontDistribution();
+    if (this.props.isPlaceholder) {
+      this.distribution = this.createCloudFrontDistributionForStub();
+    } else {
+      this.distribution = this.createCloudFrontDistribution();
+      this.addStaticBehaviorsToDistribution();
+    }
 
     // Connect Custom Domain to CloudFront Distribution
     this.createRoute53Records();
@@ -306,56 +309,51 @@ export class NextjsDistribution extends Construct {
     return this.props.functionUrlAuthType === lambda.FunctionUrlAuthType.AWS_IAM;
   }
 
-  /////////////////////
-  // CloudFront Distribution
-  /////////////////////
+  get #s3Origin(): origins.S3Origin {
+    return new origins.S3Origin(this.props.staticAssetsBucket);
+  }
 
-  private createCloudFrontDistribution(): cloudfront.Distribution {
-    const { cdk: cdkProps, cachePolicies, originRequestPolicies } = this.props;
-    const cfDistributionProps = cdkProps?.distribution;
+  get #commonBehaviorOptions(): Pick<cloudfront.BehaviorOptions, 'viewerProtocolPolicy' | 'compress'> {
+    return {
+      viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      compress: true,
+    };
+  }
 
-    // build domainNames
-    const domainNames = this.buildDistributionDomainNames();
+  get #staticBehaviorOptions(): cloudfront.BehaviorOptions {
+    const staticClientMaxAge = this.props.cachePolicies?.staticClientMaxAgeDefault || DEFAULT_STATIC_MAX_AGE;
+    const responseHeadersPolicy = new ResponseHeadersPolicy(this, 'StaticResponseHeadersPolicy', {
+      // add default header for static assets
+      customHeadersBehavior: {
+        customHeaders: [
+          {
+            header: 'cache-control',
+            override: false,
+            // by default tell browser to cache static files for this long
+            // this is separate from the origin cache policy
+            value: `public,max-age=${staticClientMaxAge},immutable`,
+          },
+        ],
+      },
+    });
+    const cachePolicy =
+      this.props.cachePolicies?.staticCachePolicy ??
+      new cloudfront.CachePolicy(this, 'StaticCachePolicy', NextjsDistribution.staticCachePolicyProps);
+    return {
+      ...this.#commonBehaviorOptions,
+      origin: this.#s3Origin,
+      allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+      cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
+      cachePolicy,
+      responseHeadersPolicy,
+    };
+  }
 
-    // S3 origin
-    const s3Origin = new origins.S3Origin(this.props.staticAssetsBucket);
+  get #fnUrlAuthType(): lambda.FunctionUrlAuthType {
+    return this.props.functionUrlAuthType || lambda.FunctionUrlAuthType.NONE;
+  }
 
-    const viewerProtocolPolicy = cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS;
-
-    // handle placeholder
-    if (this.props.isPlaceholder) {
-      return new cloudfront.Distribution(this, 'Distribution', {
-        defaultRootObject: 'index.html',
-        errorResponses: buildErrorResponsesForRedirectToIndex('index.html'),
-        domainNames,
-        certificate: this.certificate,
-        defaultBehavior: {
-          origin: s3Origin,
-          viewerProtocolPolicy,
-        },
-      });
-    }
-
-    // cache policies
-    const staticCachePolicy = cachePolicies?.staticCachePolicy ?? this.createCloudFrontStaticCachePolicy();
-    const imageCachePolicy = cachePolicies?.imageCachePolicy ?? this.createCloudFrontImageCachePolicy();
-
-    // origin request policies
-    const lambdaOriginRequestPolicy =
-      originRequestPolicies?.lambdaOriginRequestPolicy ?? this.createLambdaOriginRequestPolicy();
-
-    const fnUrlAuthType: lambda.FunctionUrlAuthType = this.props.functionUrlAuthType || lambda.FunctionUrlAuthType.NONE;
-    // main server function origin (lambda URL HTTP origin)
-    const fnUrl = this.props.serverFunction.addFunctionUrl({ authType: fnUrlAuthType });
-    const serverFunctionOrigin = new origins.HttpOrigin(Fn.parseDomainName(fnUrl.url));
-
-    // Image Optimization
-    const imageOptFnUrl = this.props.imageOptFunction.addFunctionUrl({ authType: fnUrlAuthType });
-    const imageOptFunctionOrigin = new origins.HttpOrigin(Fn.parseDomainName(imageOptFnUrl.url));
-    const imageOptORP =
-      originRequestPolicies?.imageOptimizationOriginRequestPolicy ?? this.createImageOptimizationOriginRequestPolicy();
-
-    // lambda behavior edge function
+  get #edgeLambdas(): cloudfront.EdgeLambda[] {
     const lambdaOriginRequestEdgeFn = this.buildLambdaOriginRequestEdgeFunction();
     if (this.isFnUrlIamAuth) {
       lambdaOriginRequestEdgeFn.addToRolePolicy(
@@ -370,86 +368,79 @@ export class NextjsDistribution extends Construct {
       'Version',
       lambdaOriginRequestEdgeFn.currentVersion.functionArn
     );
-    const lambdaOriginEdgeFns: cloudfront.EdgeLambda[] = [
+    return [
       {
         eventType: cloudfront.LambdaEdgeEventType.ORIGIN_REQUEST,
         functionVersion: lambdaOriginRequestEdgeFnVersion,
         includeBody: this.isFnUrlIamAuth,
       },
     ];
+  }
 
-    // default handler for requests that don't match any other path:
-    //   - try S3 bucket first
-    //   - if 403, 404, or 503 fall back to Lambda handler
-    // see discussion here: https://github.com/jetbridge/cdk-nextjs/pull/125#discussion_r1279212678
-    const fallbackOriginGroup = new origins.OriginGroup({
-      primaryOrigin: s3Origin,
-      fallbackOrigin: serverFunctionOrigin,
-      fallbackStatusCodes: [403, 404, 503],
-    });
-
-    const lambdaCachePolicy = cachePolicies?.lambdaCachePolicy ?? this.createCloudFrontLambdaCachePolicy();
-
-    // requests for static objects
-    const defaultStaticMaxAge = cachePolicies?.staticClientMaxAgeDefault?.toSeconds() || DEFAULT_STATIC_MAX_AGE;
-    const staticResponseHeadersPolicy = new ResponseHeadersPolicy(this, 'StaticResponseHeadersPolicy', {
-      // add default header for static assets
-      customHeadersBehavior: {
-        customHeaders: [
-          {
-            header: 'cache-control',
-            override: false,
-            // by default tell browser to cache static files for this long
-            // this is separate from the origin cache policy
-            value: `public,max-age=${defaultStaticMaxAge},immutable`,
-          },
-        ],
-      },
-    });
-    const staticBehavior: cloudfront.BehaviorOptions = {
-      viewerProtocolPolicy,
-      origin: s3Origin,
-      allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
-      cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
-      compress: true,
-      cachePolicy: staticCachePolicy,
-      responseHeadersPolicy: staticResponseHeadersPolicy,
-    };
-
-    // requests going to lambda (api, etc)
-    const lambdaBehavior: cloudfront.BehaviorOptions = {
-      viewerProtocolPolicy,
+  get #dynamicBehaviorOptions(): cloudfront.BehaviorOptions {
+    const fnUrl = this.props.serverFunction.addFunctionUrl({ authType: this.#fnUrlAuthType });
+    const serverFunctionOrigin = new origins.HttpOrigin(Fn.parseDomainName(fnUrl.url));
+    const originRequestPolicy = new cloudfront.OriginRequestPolicy(
+      this,
+      'LambdaOriginPolicy',
+      NextjsDistribution.dynamicOriginRequestPolicyProps
+    );
+    const cachePolicy =
+      this.props.cachePolicies?.lambdaCachePolicy ??
+      new cloudfront.CachePolicy(this, 'LambdaCache', NextjsDistribution.dynamicCachePolicyProps);
+    return {
+      ...this.#commonBehaviorOptions,
       origin: serverFunctionOrigin,
       allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
       // cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS, // this should be configurable
-      originRequestPolicy: lambdaOriginRequestPolicy,
-      compress: true,
-      cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-      edgeLambdas: lambdaOriginEdgeFns,
+      originRequestPolicy,
+      // changed from CACHING_DISABLED. Is this ok? If we need to keep CACHING_DISABLED,
+      // then we should remove props.cachePolicy.dynamic b/c it's misleading
+      cachePolicy,
+      edgeLambdas: this.#edgeLambdas,
     };
+  }
 
-    const imageBehavior: cloudfront.BehaviorOptions = {
-      viewerProtocolPolicy,
+  get #imageBehaviorOptions(): cloudfront.BehaviorOptions {
+    const imageOptFnUrl = this.props.imageOptFunction.addFunctionUrl({ authType: this.#fnUrlAuthType });
+    const imageOptFunctionOrigin = new origins.HttpOrigin(Fn.parseDomainName(imageOptFnUrl.url));
+    const originRequestPolicy =
+      this.props.originRequestPolicies?.imageOptimizationOriginRequestPolicy ??
+      new cloudfront.OriginRequestPolicy(
+        this,
+        'ImageOptPolicy',
+        NextjsDistribution.imageOptimizationOriginRequestPolicyProps
+      );
+    const cachePolicy =
+      this.props.cachePolicies?.imageCachePolicy ??
+      new cloudfront.CachePolicy(this, 'ImageCache', NextjsDistribution.imageCachePolicyProps);
+    return {
+      ...this.#commonBehaviorOptions,
       origin: imageOptFunctionOrigin,
       allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
       cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
-      compress: true,
-      cachePolicy: imageCachePolicy,
-      originRequestPolicy: imageOptORP,
-      edgeLambdas: this.isFnUrlIamAuth ? lambdaOriginEdgeFns : [],
+      cachePolicy,
+      originRequestPolicy,
+      edgeLambdas: this.isFnUrlIamAuth ? this.#edgeLambdas : [],
     };
+  }
 
-    // requests to fallback origin group (default behavior)
-    // used for S3 and lambda. would prefer to forward all headers to lambda but need to strip out host
-    // TODO: try to do this with headers whitelist or edge lambda
-    const fallbackOriginRequestPolicy =
-      originRequestPolicies?.fallbackOriginRequestPolicy ?? this.createFallbackOriginRequestPolicy();
+  /////////////////////
+  // CloudFront Distribution
+  /////////////////////
+
+  private createCloudFrontDistribution(): cloudfront.Distribution {
+    const { cdk: cdkProps } = this.props;
+    const cfDistributionProps = cdkProps?.distribution;
+
+    // build domainNames
+    const domainNames = this.buildDistributionDomainNames();
 
     // if we don't have a static file called index.html then we should
     // redirect to the lambda handler
     const hasIndexHtml = this.props.nextBuild.readPublicFileList().includes('index.html');
 
-    return new cloudfront.Distribution(this, 'Distribution', {
+    const distribution = new cloudfront.Distribution(this, 'Distribution', {
       // defaultRootObject: "index.html",
       defaultRootObject: '',
 
@@ -459,69 +450,32 @@ export class NextjsDistribution extends Construct {
       // these values can NOT be overwritten by cfDistributionProps
       domainNames,
       certificate: this.certificate,
-      defaultBehavior: {
-        origin: fallbackOriginGroup, // try S3 first, then lambda
-        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        compress: true,
-        // what goes here? static or lambda?
-        cachePolicy: lambdaCachePolicy,
-        originRequestPolicy: fallbackOriginRequestPolicy,
-        edgeLambdas: lambdaOriginEdgeFns,
-      },
+      defaultBehavior: this.#dynamicBehaviorOptions,
 
       additionalBehaviors: {
         // is index.html static or dynamic?
-        ...(hasIndexHtml ? {} : { '/': lambdaBehavior }),
-
-        // known dynamic routes
-        'api/*': lambdaBehavior,
-        '_next/data/*': lambdaBehavior,
+        ...(hasIndexHtml ? {} : { '/': this.#dynamicBehaviorOptions }),
 
         // dynamic images go to lambda
-        '_next/image*': imageBehavior,
+        '_next/image*': this.#imageBehaviorOptions,
 
         // known static routes
-        // it would be nice to create routes for all the static files we know of
-        // but we run into the limit of CacheBehaviors per distribution
-        '_next/*': staticBehavior,
+        '_next/*': this.#staticBehaviorOptions,
       },
     });
+    return distribution;
   }
 
-  private createCloudFrontStaticCachePolicy(): cloudfront.CachePolicy {
-    return new cloudfront.CachePolicy(this, 'StaticsCache', NextjsDistribution.staticCachePolicyProps);
-  }
-
-  private createCloudFrontImageCachePolicy(): cloudfront.CachePolicy {
-    return new cloudfront.CachePolicy(this, 'ImageCache', NextjsDistribution.imageCachePolicyProps);
-  }
-
-  private createLambdaOriginRequestPolicy(): cloudfront.OriginRequestPolicy {
-    return new cloudfront.OriginRequestPolicy(
-      this,
-      'LambdaOriginPolicy',
-      NextjsDistribution.lambdaOriginRequestPolicyProps
-    );
-  }
-
-  private createFallbackOriginRequestPolicy(): cloudfront.OriginRequestPolicy {
-    return new cloudfront.OriginRequestPolicy(
-      this,
-      'FallbackOriginRequestPolicy',
-      NextjsDistribution.fallbackOriginRequestPolicyProps
-    );
-  }
-
-  private createImageOptimizationOriginRequestPolicy(): cloudfront.OriginRequestPolicy {
-    return new cloudfront.OriginRequestPolicy(
-      this,
-      'ImageOptPolicy',
-      NextjsDistribution.imageOptimizationOriginRequestPolicyProps
-    );
-  }
-
-  private createCloudFrontLambdaCachePolicy(): cloudfront.CachePolicy {
-    return new cloudfront.CachePolicy(this, 'LambdaCache', NextjsDistribution.lambdaCachePolicyProps);
+  private addStaticBehaviorsToDistribution() {
+    const publicFiles = this.props.nextBuild.readPublicFileList();
+    for (const publicFile of publicFiles) {
+      const isDir = fs.statSync(publicFile).isDirectory();
+      this.distribution.addBehavior(
+        isDir ? `${publicFile}/*` : publicFile,
+        this.#s3Origin,
+        this.#staticBehaviorOptions
+      );
+    }
   }
 
   private createCloudFrontDistributionForStub(): cloudfront.Distribution {
@@ -552,9 +506,8 @@ export class NextjsDistribution extends Construct {
    * Create an edge function to handle requests to the lambda server handler origin.
    * It overrides the host header in the request to be the lambda URL's host.
    * It's needed because we forward all headers to the origin, but the origin is itself an
-   *  HTTP server so it needs the host header to be the address of the lambda and not
-   *  the distribution.
-   *
+   * HTTP server so it needs the host header to be the address of the lambda and not
+   * the distribution.
    */
   private buildLambdaOriginRequestEdgeFunction() {
     const app = App.of(this) as App;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,11 @@ export const LAMBDA_RUNTIME = Runtime.NODEJS_18_X;
 export const DEFAULT_LAMBA_MEMORY = 1536;
 
 export const CACHE_BUCKET_KEY_PREFIX = '_cache';
+
+export const NEXTJS_STATIC_DIR = 'assets';
+export const NEXTJS_BUILD_DIR = '.open-next';
+export const NEXTJS_CACHE_DIR = 'cache';
+export const NEXTJS_BUILD_MIDDLEWARE_FN_DIR = 'middleware-function';
+export const NEXTJS_BUILD_REVALIDATE_FN_DIR = 'revalidation-function';
+export const NEXTJS_BUILD_IMAGE_FN_DIR = 'image-optimization-function';
+export const NEXTJS_BUILD_SERVER_FN_DIR = 'server-function';


### PR DESCRIPTION
Fixes #129 

- Refactor massive `createDistribution` so more readable/maintainable
- Change variables referencing “lambda” to “dynamic” or “server”. “Lambda” is confusing b/c there are multiple lambdas including image optimization and revalidation
- Add `NextjsDomain` construct for to simplify `NextjsDistribution`
- The default behavior is now the dynamic (previously lambda) behavior option. Therefore, I don’t need to add explicit behaviors for dynamic routes like api/* or _next/data/* because they’ll be handled by default option. In doing this, I removed the `lambdaCachePolicy` which confusingly wasn’t used by lambda behavior but default behavior. Is that ok? Should I change dynamic behavior to use dynamicCachePolicy? I think yes.