### PR TITLE
feat: add dynamodb table and provider for tag and path revalidation

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.95.1",
+      "version": "2.99.1",
       "type": "build"
     },
     {
@@ -173,7 +173,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.95.1",
+      "version": "^2.99.1",
       "type": "peer"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.93.0",
+      "version": "2.95.1",
       "type": "build"
     },
     {
@@ -173,7 +173,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.93.0",
+      "version": "^2.95.1",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -49,7 +49,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   gitignore: ['.idea'],
   // dependency config
   jsiiVersion: '~5.0.0',
-  cdkVersion: '2.95.1',
+  cdkVersion: '2.99.1',
   bundledDeps: ['esbuild'] /* Runtime dependencies of this module. */,
   devDeps: [
     '@aws-crypto/sha256-js',

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -49,7 +49,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   gitignore: ['.idea'],
   // dependency config
   jsiiVersion: '~5.0.0',
-  cdkVersion: '2.93.0',
+  cdkVersion: '2.95.1',
   bundledDeps: ['esbuild'] /* Runtime dependencies of this module. */,
   devDeps: [
     '@aws-crypto/sha256-js',

--- a/API.md
+++ b/API.md
@@ -2174,9 +2174,9 @@ Any object.
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.queue">queue</a></code> | <code>aws-cdk-lib.aws_sqs.Queue</code> | *No description.* |
-| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.queueFunction">queueFunction</a></code> | <code>aws-cdk-lib.aws_lambda_nodejs.NodejsFunction</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.queueFunction">queueFunction</a></code> | <code>aws-cdk-lib.aws_lambda.Function</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.table">table</a></code> | <code>aws-cdk-lib.aws_dynamodb.TableV2</code> | *No description.* |
-| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.tableFunction">tableFunction</a></code> | <code>aws-cdk-lib.aws_lambda_nodejs.NodejsFunction</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.tableFunction">tableFunction</a></code> | <code>aws-cdk-lib.aws_lambda.Function</code> | *No description.* |
 
 ---
 
@@ -2205,10 +2205,10 @@ public readonly queue: Queue;
 ##### `queueFunction`<sup>Required</sup> <a name="queueFunction" id="cdk-nextjs-standalone.NextjsRevalidation.property.queueFunction"></a>
 
 ```typescript
-public readonly queueFunction: NodejsFunction;
+public readonly queueFunction: Function;
 ```
 
-- *Type:* aws-cdk-lib.aws_lambda_nodejs.NodejsFunction
+- *Type:* aws-cdk-lib.aws_lambda.Function
 
 ---
 
@@ -2225,10 +2225,10 @@ public readonly table: TableV2;
 ##### `tableFunction`<sup>Optional</sup> <a name="tableFunction" id="cdk-nextjs-standalone.NextjsRevalidation.property.tableFunction"></a>
 
 ```typescript
-public readonly tableFunction: NodejsFunction;
+public readonly tableFunction: Function;
 ```
 
-- *Type:* aws-cdk-lib.aws_lambda_nodejs.NodejsFunction
+- *Type:* aws-cdk-lib.aws_lambda.Function
 
 ---
 
@@ -3684,7 +3684,7 @@ const nextjsImageProps: NextjsImageProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsImageProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsImageProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The S3 bucket holding application images. |
 | <code><a href="#cdk-nextjs-standalone.NextjsImageProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | The `NextjsBuild` instance representing the built Nextjs application. |
-| <code><a href="#cdk-nextjs-standalone.NextjsImageProps.property.lambdaOptions">lambdaOptions</a></code> | <code>aws-cdk-lib.aws_lambda_nodejs.NodejsFunctionProps</code> | Override function properties. |
+| <code><a href="#cdk-nextjs-standalone.NextjsImageProps.property.lambdaOptions">lambdaOptions</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
 
 ---
 
@@ -3839,10 +3839,10 @@ The `NextjsBuild` instance representing the built Nextjs application.
 ##### `lambdaOptions`<sup>Optional</sup> <a name="lambdaOptions" id="cdk-nextjs-standalone.NextjsImageProps.property.lambdaOptions"></a>
 
 ```typescript
-public readonly lambdaOptions: NodejsFunctionProps;
+public readonly lambdaOptions: FunctionOptions;
 ```
 
-- *Type:* aws-cdk-lib.aws_lambda_nodejs.NodejsFunctionProps
+- *Type:* aws-cdk-lib.aws_lambda.FunctionOptions
 
 Override function properties.
 

--- a/API.md
+++ b/API.md
@@ -2631,7 +2631,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2.2 build'
+- *Default:* 'npx --yes open-next@^2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -2920,7 +2920,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2.2 build'
+- *Default:* 'npx --yes open-next@^2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -3252,7 +3252,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2.2 build'
+- *Default:* 'npx --yes open-next@^2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -3709,7 +3709,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2.2 build'
+- *Default:* 'npx --yes open-next@^2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -3984,7 +3984,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2.2 build'
+- *Default:* 'npx --yes open-next@^2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -4209,7 +4209,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2.2 build'
+- *Default:* 'npx --yes open-next@^2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -4398,7 +4398,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2.2 build'
+- *Default:* 'npx --yes open-next@^2 build'
 
 Optional value used to install NextJS node dependencies.
 

--- a/API.md
+++ b/API.md
@@ -602,6 +602,7 @@ Any object.
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextCacheDir">nextCacheDir</a></code> | <code>string</code> | Cache directory for generated data. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextImageFnDir">nextImageFnDir</a></code> | <code>string</code> | Contains function for processessing image requests. |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextRevalidateDynamoDBProviderFnDir">nextRevalidateDynamoDBProviderFnDir</a></code> | <code>string</code> | Contains function for inserting revalidation items into the table. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextRevalidateFnDir">nextRevalidateFnDir</a></code> | <code>string</code> | Contains function for processing items from revalidation queue. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextServerFnDir">nextServerFnDir</a></code> | <code>string</code> | Contains server code and dependencies. |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuild.property.nextStaticDir">nextStaticDir</a></code> | <code>string</code> | Static files containing client-side code. |
@@ -644,6 +645,18 @@ public readonly nextImageFnDir: string;
 Contains function for processessing image requests.
 
 Should be arm64.
+
+---
+
+##### `nextRevalidateDynamoDBProviderFnDir`<sup>Required</sup> <a name="nextRevalidateDynamoDBProviderFnDir" id="cdk-nextjs-standalone.NextjsBuild.property.nextRevalidateDynamoDBProviderFnDir"></a>
+
+```typescript
+public readonly nextRevalidateDynamoDBProviderFnDir: string;
+```
+
+- *Type:* string
+
+Contains function for inserting revalidation items into the table.
 
 ---
 
@@ -2075,7 +2088,7 @@ The tree node.
 
 ### NextjsRevalidation <a name="NextjsRevalidation" id="cdk-nextjs-standalone.NextjsRevalidation"></a>
 
-Builds the system for revalidating Next.js resources. This includes a Lambda function handler and queue system.
+Builds the system for revalidating Next.js resources. This includes a Lambda function handler and queue system as well as the DynamoDB table and provider function.
 
 > [{@link https://github.com/serverless-stack/open-next/blob/main/README.md?plain=1#L65}]({@link https://github.com/serverless-stack/open-next/blob/main/README.md?plain=1#L65})
 
@@ -2160,8 +2173,10 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.function">function</a></code> | <code>aws-cdk-lib.aws_lambda.Function</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.queue">queue</a></code> | <code>aws-cdk-lib.aws_sqs.Queue</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.queueFunction">queueFunction</a></code> | <code>aws-cdk-lib.aws_lambda_nodejs.NodejsFunction</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.table">table</a></code> | <code>aws-cdk-lib.aws_dynamodb.TableV2</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsRevalidation.property.tableFunction">tableFunction</a></code> | <code>aws-cdk-lib.aws_lambda_nodejs.NodejsFunction</code> | *No description.* |
 
 ---
 
@@ -2177,16 +2192,6 @@ The tree node.
 
 ---
 
-##### `function`<sup>Required</sup> <a name="function" id="cdk-nextjs-standalone.NextjsRevalidation.property.function"></a>
-
-```typescript
-public readonly function: Function;
-```
-
-- *Type:* aws-cdk-lib.aws_lambda.Function
-
----
-
 ##### `queue`<sup>Required</sup> <a name="queue" id="cdk-nextjs-standalone.NextjsRevalidation.property.queue"></a>
 
 ```typescript
@@ -2194,6 +2199,36 @@ public readonly queue: Queue;
 ```
 
 - *Type:* aws-cdk-lib.aws_sqs.Queue
+
+---
+
+##### `queueFunction`<sup>Required</sup> <a name="queueFunction" id="cdk-nextjs-standalone.NextjsRevalidation.property.queueFunction"></a>
+
+```typescript
+public readonly queueFunction: NodejsFunction;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda_nodejs.NodejsFunction
+
+---
+
+##### `table`<sup>Required</sup> <a name="table" id="cdk-nextjs-standalone.NextjsRevalidation.property.table"></a>
+
+```typescript
+public readonly table: TableV2;
+```
+
+- *Type:* aws-cdk-lib.aws_dynamodb.TableV2
+
+---
+
+##### `tableFunction`<sup>Optional</sup> <a name="tableFunction" id="cdk-nextjs-standalone.NextjsRevalidation.property.tableFunction"></a>
+
+```typescript
+public readonly tableFunction: NodejsFunction;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda_nodejs.NodejsFunction
 
 ---
 
@@ -3649,7 +3684,7 @@ const nextjsImageProps: NextjsImageProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsImageProps.property.tempBuildDir">tempBuildDir</a></code> | <code>string</code> | Directory to store temporary build files in. |
 | <code><a href="#cdk-nextjs-standalone.NextjsImageProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The S3 bucket holding application images. |
 | <code><a href="#cdk-nextjs-standalone.NextjsImageProps.property.nextBuild">nextBuild</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsBuild">NextjsBuild</a></code> | The `NextjsBuild` instance representing the built Nextjs application. |
-| <code><a href="#cdk-nextjs-standalone.NextjsImageProps.property.lambdaOptions">lambdaOptions</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionOptions</code> | Override function properties. |
+| <code><a href="#cdk-nextjs-standalone.NextjsImageProps.property.lambdaOptions">lambdaOptions</a></code> | <code>aws-cdk-lib.aws_lambda_nodejs.NodejsFunctionProps</code> | Override function properties. |
 
 ---
 
@@ -3804,10 +3839,10 @@ The `NextjsBuild` instance representing the built Nextjs application.
 ##### `lambdaOptions`<sup>Optional</sup> <a name="lambdaOptions" id="cdk-nextjs-standalone.NextjsImageProps.property.lambdaOptions"></a>
 
 ```typescript
-public readonly lambdaOptions: FunctionOptions;
+public readonly lambdaOptions: NodejsFunctionProps;
 ```
 
-- *Type:* aws-cdk-lib.aws_lambda.FunctionOptions
+- *Type:* aws-cdk-lib.aws_lambda_nodejs.NodejsFunctionProps
 
 Override function properties.
 

--- a/API.md
+++ b/API.md
@@ -2631,7 +2631,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2 build'
+- *Default:* 'npx --yes open-next@2.2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -2920,7 +2920,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2 build'
+- *Default:* 'npx --yes open-next@2.2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -3252,7 +3252,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2 build'
+- *Default:* 'npx --yes open-next@2.2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -3709,7 +3709,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2 build'
+- *Default:* 'npx --yes open-next@2.2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -3984,7 +3984,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2 build'
+- *Default:* 'npx --yes open-next@2.2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -4209,7 +4209,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2 build'
+- *Default:* 'npx --yes open-next@2.2 build'
 
 Optional value used to install NextJS node dependencies.
 
@@ -4398,7 +4398,7 @@ public readonly buildCommand: string;
 ```
 
 - *Type:* string
-- *Default:* 'npx --yes open-next@2 build'
+- *Default:* 'npx --yes open-next@2.2 build'
 
 Optional value used to install NextJS node dependencies.
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.95.1",
+    "aws-cdk-lib": "2.99.1",
     "aws-lambda": "^1.0.7",
     "constructs": "10.0.5",
     "esbuild": "^0.19.2",
@@ -81,7 +81,7 @@
     "undici": "^5.23.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.95.1",
+    "aws-cdk-lib": "^2.99.1",
     "constructs": "^10.0.5"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.93.0",
+    "aws-cdk-lib": "2.95.1",
     "aws-lambda": "^1.0.7",
     "constructs": "10.0.5",
     "esbuild": "^0.19.2",
@@ -81,7 +81,7 @@
     "undici": "^5.23.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.93.0",
+    "aws-cdk-lib": "^2.95.1",
     "constructs": "^10.0.5"
   },
   "dependencies": {

--- a/src/NextjsBase.ts
+++ b/src/NextjsBase.ts
@@ -37,7 +37,7 @@ export interface NextjsBaseProps {
 
   /**
    * Optional value used to install NextJS node dependencies.
-   * @default 'npx --yes open-next@2.2 build'
+   * @default 'npx --yes open-next@^2 build'
    */
   readonly buildCommand?: string;
 

--- a/src/NextjsBase.ts
+++ b/src/NextjsBase.ts
@@ -37,7 +37,7 @@ export interface NextjsBaseProps {
 
   /**
    * Optional value used to install NextJS node dependencies.
-   * @default 'npx --yes open-next@2 build'
+   * @default 'npx --yes open-next@2.2 build'
    */
   readonly buildCommand?: string;
 

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -110,7 +110,7 @@ export class NextjsBuild extends Construct {
 
   private build() {
     const buildPath = this.props.buildPath ?? this.props.nextjsPath;
-    const buildCommand = this.props.buildCommand ?? 'npx open-next@2.2 build';
+    const buildCommand = this.props.buildCommand ?? 'npx open-next@^2 build';
     // run build
     if (!this.props.quiet) {
       console.debug(`├ Running "${buildCommand}" in`, buildPath);

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -10,6 +10,7 @@ import {
   NEXTJS_BUILD_SERVER_FN_DIR,
   NEXTJS_STATIC_DIR,
   NEXTJS_CACHE_DIR,
+  NEXTJS_BUILD_DYNAMODB_PROVIDER_FN_DIR,
 } from './constants';
 import { NextjsBaseProps } from './NextjsBase';
 import { NextjsBucketDeployment } from './NextjsBucketDeployment';
@@ -48,6 +49,14 @@ export class NextjsBuild extends Construct {
    */
   public get nextRevalidateFnDir(): string {
     const fnPath = path.join(this.getNextBuildDir(), NEXTJS_BUILD_REVALIDATE_FN_DIR);
+    this.warnIfMissing(fnPath);
+    return fnPath;
+  }
+  /**
+   * Contains function for inserting revalidation items into the table.
+   */
+  public get nextRevalidateDynamoDBProviderFnDir(): string {
+    const fnPath = path.join(this.getNextBuildDir(), NEXTJS_BUILD_DYNAMODB_PROVIDER_FN_DIR);
     this.warnIfMissing(fnPath);
     return fnPath;
   }

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -110,7 +110,7 @@ export class NextjsBuild extends Construct {
 
   private build() {
     const buildPath = this.props.buildPath ?? this.props.nextjsPath;
-    const buildCommand = this.props.buildCommand ?? 'npx open-next@2 build';
+    const buildCommand = this.props.buildCommand ?? 'npx open-next@2.2 build';
     // run build
     if (!this.props.quiet) {
       console.debug(`├ Running "${buildCommand}" in`, buildPath);

--- a/src/NextjsImage.ts
+++ b/src/NextjsImage.ts
@@ -32,7 +32,7 @@ export class NextjsImage extends LambdaFunction {
       ...commonFnProps,
       code: Code.fromAsset(props.nextBuild.nextImageFnDir),
       handler: 'index.handler',
-      description: 'Next.js image optimization function',
+      description: 'Next.js Image Optimization Function',
       ...lambdaOptions,
       environment: {
         BUCKET_NAME: bucket.bucketName,

--- a/src/NextjsImage.ts
+++ b/src/NextjsImage.ts
@@ -32,7 +32,7 @@ export class NextjsImage extends LambdaFunction {
       ...commonFnProps,
       code: Code.fromAsset(props.nextBuild.nextImageFnDir),
       handler: 'index.handler',
-      description: 'Next.js Image Optimization Function',
+      description: 'Next.js image optimization function',
       ...lambdaOptions,
       environment: {
         BUCKET_NAME: bucket.bucketName,

--- a/src/NextjsRevalidation.ts
+++ b/src/NextjsRevalidation.ts
@@ -54,7 +54,6 @@ export class NextjsRevalidation extends Construct {
     this.table = this.createRevalidationTable();
     this.tableFunction = this.createRevalidationInsertFunction(this.table);
 
-    // todo: set these things
     this.props.serverFunction.lambdaFunction.addEnvironment('CACHE_DYNAMO_TABLE', this.table.tableName);
     this.table.grantReadWriteData(this.props.serverFunction.lambdaFunction.role!);
 
@@ -94,7 +93,7 @@ export class NextjsRevalidation extends Construct {
       // see: https://github.com/serverless-stack/open-next/blob/274d446ed7e940cfbe7ce05a21108f4c854ee37a/README.md?plain=1#L65
       code: Code.fromAsset(this.props.nextBuild.nextRevalidateFnDir),
       handler: 'index.handler',
-      description: 'Next.js queue revalidation function',
+      description: 'Next.js Queue Revalidation Function',
       timeout: Duration.seconds(30),
     });
     fn.addEventSource(new SqsEventSource(this.queue, { batchSize: 5 }));
@@ -137,7 +136,7 @@ export class NextjsRevalidation extends Construct {
         // see: https://github.com/serverless-stack/open-next/blob/274d446ed7e940cfbe7ce05a21108f4c854ee37a/README.md?plain=1#L65
         code: Code.fromAsset(this.props.nextBuild.nextRevalidateDynamoDBProviderFnDir),
         handler: 'index.handler',
-        description: 'Next.js revalidation DynamoDB provider',
+        description: 'Next.js Revalidation DynamoDB Provider',
         timeout: Duration.minutes(15),
         initialPolicy: [
           new PolicyStatement({

--- a/src/NextjsRevalidation.ts
+++ b/src/NextjsRevalidation.ts
@@ -1,8 +1,13 @@
-import { Duration, Stack } from 'aws-cdk-lib';
+import * as fs from 'fs';
+import { CustomResource, Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { AttributeType, Billing, TableV2 as Table } from 'aws-cdk-lib/aws-dynamodb';
 import { AnyPrincipal, Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Code, Function as LambdaFunction, FunctionOptions } from 'aws-cdk-lib/aws-lambda';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
+import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { NextjsBaseProps } from './NextjsBase';
 import { NextjsBuild } from './NextjsBuild';
@@ -27,14 +32,17 @@ export interface NextjsRevalidationProps extends NextjsBaseProps {
 }
 
 /**
- * Builds the system for revalidating Next.js resources. This includes a Lambda function handler and queue system.
+ * Builds the system for revalidating Next.js resources. This includes a Lambda function handler and queue system as well
+ * as the DynamoDB table and provider function.
  *
  * @see {@link https://github.com/serverless-stack/open-next/blob/main/README.md?plain=1#L65}
  *
  */
 export class NextjsRevalidation extends Construct {
   queue: Queue;
-  function: LambdaFunction;
+  table: Table;
+  queueFunction: LambdaFunction;
+  tableFunction: LambdaFunction | undefined;
   private props: NextjsRevalidationProps;
 
   constructor(scope: Construct, id: string, props: NextjsRevalidationProps) {
@@ -42,10 +50,17 @@ export class NextjsRevalidation extends Construct {
     this.props = props;
 
     this.queue = this.createQueue();
-    this.function = this.createFunction();
+    this.queueFunction = this.createFunction();
 
-    // allow server fn to send messages to queue
-    props.serverFunction.lambdaFunction?.addEnvironment('REVALIDATION_QUEUE_URL', this.queue.queueUrl);
+    this.table = this.createRevalidationTable();
+    this.tableFunction = this.createRevalidationInsertFunction(this.table);
+
+    // todo: set these things
+    this.props.serverFunction.lambdaFunction.addEnvironment('CACHE_DYNAMO_TABLE', this.table.tableName);
+    this.table.grantReadWriteData(this.props.serverFunction.lambdaFunction.role!);
+
+    this.props.serverFunction.lambdaFunction // allow server fn to send messages to queue
+      ?.addEnvironment('REVALIDATION_QUEUE_URL', this.queue.queueUrl);
     props.serverFunction.lambdaFunction?.addEnvironment('REVALIDATION_QUEUE_REGION', Stack.of(this).region);
   }
 
@@ -74,16 +89,84 @@ export class NextjsRevalidation extends Construct {
 
   private createFunction(): LambdaFunction {
     const commonFnProps = getCommonFunctionProps(this);
-    const fn = new LambdaFunction(this, 'Fn', {
+    const fn = new LambdaFunction(this, 'QueueFn', {
       ...commonFnProps,
       // open-next revalidation-function
       // see: https://github.com/serverless-stack/open-next/blob/274d446ed7e940cfbe7ce05a21108f4c854ee37a/README.md?plain=1#L65
       code: Code.fromAsset(this.props.nextBuild.nextRevalidateFnDir),
       handler: 'index.handler',
-      description: 'Next.js revalidation function',
+      description: 'Next.js queue revalidation function',
       timeout: Duration.seconds(30),
     });
     fn.addEventSource(new SqsEventSource(this.queue, { batchSize: 5 }));
     return fn;
+  }
+
+  private createRevalidationTable() {
+    return new Table(this, 'RevalidationTable', {
+      partitionKey: { name: 'tag', type: AttributeType.STRING },
+      sortKey: { name: 'path', type: AttributeType.STRING },
+      pointInTimeRecovery: true,
+      billing: Billing.onDemand(),
+      globalSecondaryIndexes: [
+        {
+          indexName: 'revalidate',
+          partitionKey: { name: 'path', type: AttributeType.STRING },
+          sortKey: { name: 'revalidatedAt', type: AttributeType.NUMBER },
+        },
+      ],
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+  }
+
+  /**
+   * This function will insert the initial batch of tag / path / revalidation data into the DynamoDB table during deployment.
+   * @see: {@link https://open-next.js.org/inner_workings/isr#tags}
+   *
+   * @param revalidationTable table to grant function access to
+   * @returns the revalidation insert provider function
+   */
+  private createRevalidationInsertFunction(revalidationTable: Table) {
+    const dynamodbProviderPath = this.props.nextBuild.nextRevalidateDynamoDBProviderFnDir;
+
+    // note the function may not exist - it only exists if there are cache tags values defined in Next.js build meta files to be inserted
+    // see: https://github.com/sst/open-next/blob/c2b05e3a5f82de40da1181e11c087265983c349d/packages/open-next/src/build.ts#L426-L458
+    if (fs.existsSync(dynamodbProviderPath)) {
+      const commonFnProps = getCommonFunctionProps(this);
+      const insertFn = new LambdaFunction(this, 'DynamoDBProviderFn', {
+        ...commonFnProps,
+        // open-next revalidation-function
+        // see: https://github.com/serverless-stack/open-next/blob/274d446ed7e940cfbe7ce05a21108f4c854ee37a/README.md?plain=1#L65
+        code: Code.fromAsset(this.props.nextBuild.nextRevalidateDynamoDBProviderFnDir),
+        handler: 'index.handler',
+        description: 'Next.js revalidation DynamoDB provider',
+        timeout: Duration.minutes(15),
+        initialPolicy: [
+          new PolicyStatement({
+            actions: ['dynamodb:BatchWriteItem', 'dynamodb:PutItem', 'dynamodb:DescribeTable'],
+            resources: [revalidationTable.tableArn],
+          }),
+        ],
+        environment: {
+          CACHE_DYNAMO_TABLE: revalidationTable.tableName,
+        },
+      });
+
+      const provider = new Provider(this, 'RevalidationProvider', {
+        onEventHandler: insertFn,
+        logRetention: RetentionDays.ONE_DAY,
+      });
+
+      new CustomResource(this, 'RevalidationResource', {
+        serviceToken: provider.serviceToken,
+        properties: {
+          version: Date.now().toString(),
+        },
+      });
+
+      return insertFn;
+    }
+
+    return undefined;
   }
 }

--- a/src/NextjsRevalidation.ts
+++ b/src/NextjsRevalidation.ts
@@ -4,7 +4,6 @@ import { AttributeType, Billing, TableV2 as Table } from 'aws-cdk-lib/aws-dynamo
 import { AnyPrincipal, Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Code, Function as LambdaFunction, FunctionOptions } from 'aws-cdk-lib/aws-lambda';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
-import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
 import { Provider } from 'aws-cdk-lib/custom-resources';
@@ -103,10 +102,9 @@ export class NextjsRevalidation extends Construct {
   }
 
   private createRevalidationTable() {
-    return new Table(this, 'RevalidationTable', {
+    return new Table(this, 'Table', {
       partitionKey: { name: 'tag', type: AttributeType.STRING },
       sortKey: { name: 'path', type: AttributeType.STRING },
-      pointInTimeRecovery: true,
       billing: Billing.onDemand(),
       globalSecondaryIndexes: [
         {
@@ -152,12 +150,12 @@ export class NextjsRevalidation extends Construct {
         },
       });
 
-      const provider = new Provider(this, 'RevalidationProvider', {
+      const provider = new Provider(this, 'DynamoDBProvider', {
         onEventHandler: insertFn,
         logRetention: RetentionDays.ONE_DAY,
       });
 
-      new CustomResource(this, 'RevalidationResource', {
+      new CustomResource(this, 'DynamoDBResource', {
         serviceToken: provider.serviceToken,
         properties: {
           version: Date.now().toString(),

--- a/src/NextjsServer.ts
+++ b/src/NextjsServer.ts
@@ -116,7 +116,7 @@ export class NextjsServer extends Construct {
       ...getCommonFunctionProps(this),
       code: Code.fromBucket(asset.bucket, asset.s3ObjectKey),
       handler: 'index.handler',
-      description: 'Next.js server handler',
+      description: 'Next.js Server Handler',
       ...this.props.lambda,
       // `environment` needs to go after `this.props.lambda` b/c if
       // `this.props.lambda.environment` is defined, it will override

--- a/src/NextjsServer.ts
+++ b/src/NextjsServer.ts
@@ -116,6 +116,7 @@ export class NextjsServer extends Construct {
       ...getCommonFunctionProps(this),
       code: Code.fromBucket(asset.bucket, asset.s3ObjectKey),
       handler: 'index.handler',
+      description: 'Next.js server handler',
       ...this.props.lambda,
       // `environment` needs to go after `this.props.lambda` b/c if
       // `this.props.lambda.environment` is defined, it will override

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,5 +9,6 @@ export const NEXTJS_STATIC_DIR = 'assets';
 export const NEXTJS_BUILD_DIR = '.open-next';
 export const NEXTJS_CACHE_DIR = 'cache';
 export const NEXTJS_BUILD_REVALIDATE_FN_DIR = 'revalidation-function';
+export const NEXTJS_BUILD_DYNAMODB_PROVIDER_FN_DIR = 'dynamodb-provider';
 export const NEXTJS_BUILD_IMAGE_FN_DIR = 'image-optimization-function';
 export const NEXTJS_BUILD_SERVER_FN_DIR = 'server-function';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,10 +2515,10 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.95.1:
-  version "2.95.1"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.95.1.tgz#624321c7c0b6e6417a9f1bdbc07bd7fc2fee5eee"
-  integrity sha512-FQlnW3+c1j2W7hmu+QMSiWnBgbW1Lhn1ZpBQ6cwYZa97rII1zlEyTowAfzQk6szPIzUhJv5xK03nWZtvCvpAWw==
+aws-cdk-lib@2.99.1:
+  version "2.99.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.99.1.tgz#e2cd3e091fa9c65ca2835ad9a4bb6564e6b42189"
+  integrity sha512-mUhuT2JTy3VyX9o9IOSuy7UYDimFHGnmpASwTb4rD10Hksb1dTqqN2BsXU5kogHakYevBD3vwYc87rOVso4M7Q==
   dependencies:
     "@aws-cdk/asset-awscli-v1" "^2.2.200"
     "@aws-cdk/asset-kubectl-v20" "^2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,10 +2515,10 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.93.0:
-  version "2.93.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.93.0.tgz#545bc0072bc0f2e27cb0fecb0c9e54de29b10731"
-  integrity sha512-kKbcKkts272Ju5xjGKI3pXTOpiJxW4OQbDF8Vmw/NIkkuJLo8GlRCFfeOfoN/hilvlYQgENA67GCgSWccbvu7w==
+aws-cdk-lib@2.95.1:
+  version "2.95.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.95.1.tgz#624321c7c0b6e6417a9f1bdbc07bd7fc2fee5eee"
+  integrity sha512-FQlnW3+c1j2W7hmu+QMSiWnBgbW1Lhn1ZpBQ6cwYZa97rII1zlEyTowAfzQk6szPIzUhJv5xK03nWZtvCvpAWw==
   dependencies:
     "@aws-cdk/asset-awscli-v1" "^2.2.200"
     "@aws-cdk/asset-kubectl-v20" "^2.1.2"


### PR DESCRIPTION
This diff adds the DynamoDB table and supporting data provider function to support Next.js path and tag revalition. This feature is supported by `open-next` (read more about it here: https://open-next.js.org/inner_workings/isr#tags) and is inspired by https://github.com/sst/sst/compare/v2.27.0...v2.28.0

The changes include

* Adding a new DynamoDB table which stores time stamps, tags, and paths for revalidation consideration
* Adds a function (`dynamodb-provider`) which populates the DynamoDB table on deployment with the initial set of tags / paths / timestamps generated in the Next.js build phase
* **Bumps `aws-cdk-lib` to 2.95.1**, matching the SST version for access to `DynamoDB.TableV2`
* Adds a simple description to the "primary" server handler

A bit more info:

### Bump of `aws-cdk-lib` 2.95.1

I did this because SST uses the DynamoDB `TableV2` construct and I thought it would be best to match.

### Description of ServerFunction

I added a description because at least for me the function names end up mangled (I actually think it’d be great to clean these up, but I frankly don’t know the best practice here from IaC / AWS perspective) and it’s nice to be able to easily identify different functions, in particular the server handler, in the AWS console for debugging.

### Non breaking change, but…

From what I can tell this is a non-breaking change, however this brings me back to a general question about how we should be managing versions and default open-next build commands… SST uses `2.2.1` as the default version of `open-next` in the build command.

#143 