### PR TITLE
fix: skip asset bundling if cdk deploy is made with --exclusively flag

### DIFF
--- a/src/NextjsStaticAssets.ts
+++ b/src/NextjsStaticAssets.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
-import { RemovalPolicy } from 'aws-cdk-lib';
+import { RemovalPolicy, Stack } from 'aws-cdk-lib';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { Asset } from 'aws-cdk-lib/aws-s3-assets';
 import { Construct } from 'constructs';
@@ -63,8 +63,12 @@ export class NextjsStaticAssets extends Construct {
     this.props = props;
 
     this.bucket = this.createBucket();
-    const asset = this.createAsset();
-    this.createBucketDeployment(asset);
+
+    // when `cdk deploy "NonNextjsStack" --exclusively` is run, don't bundle assets since they will not exist
+    if (Stack.of(this).bundlingRequired) {
+      const asset = this.createAsset();
+      this.createBucketDeployment(asset);
+    }
   }
 
   private createBucket(): s3.IBucket {


### PR DESCRIPTION
This pull request closes #160.

Currently there is a check in `NextjsBuild.ts` https://github.com/jetbridge/cdk-nextjs/blob/15deeb7cf6a6f8963d796f92526d78dbfe7070f3/src/NextjsBuild.ts#L87 if the deploy is being made with the `--exclusively` flag and then the build is skipped.

This check is not present when creating S3 assets, so it will try to copy asset files from the `.open-next` folder, which does not exist if the build has been skipped. https://github.com/jetbridge/cdk-nextjs/blob/15deeb7cf6a6f8963d796f92526d78dbfe7070f3/src/NextjsStaticAssets.ts#L66

This causes any deployment to fail with the following error:
```
Warning: /home/runner/work/<app-name>/<app-name>/clients/website/.open-next does not exist.
Warning: /home/runner/work/<app-name>/<app-name>/clients/website/.open-next/assets does not exist.
Error: ENOENT: no such file or directory, lstat '/home/runner/work/<app-name>/<app-name>/clients/website/.open-next/assets'
    at lstatSync (node:fs:1668:3)
    at statFunc (node:internal/fs/cp/cp-sync:122:15)
    at getStatsSync (node:internal/fs/cp/cp-sync:123:19)
    at checkPathsSync (node:internal/fs/cp/cp-sync:72:33)
    at cpSyncFn (node:internal/fs/cp/cp-sync:58:42)
    at NextjsStaticAssets.createAsset (/home/runner/work/<app-name>/<app-name>/node_modules/cdk-nextjs-standalone/src/NextjsStaticAssets.ts:86:8)
    at new NextjsStaticAssets (/home/runner/work/<app-name>/<app-name>/node_modules/cdk-nextjs-standalone/src/NextjsStaticAssets.ts:66:24)
    at new Nextjs (/home/runner/work/<app-name>/<app-name>/node_modules/cdk-nextjs-standalone/src/Nextjs.ts:142:25)
    at new PublicWebsiteStack (/home/runner/work/<app-name>/<app-name>/infrastructure/stacks/public-website-stack.ts:30:20) {
  errno: -2,
  syscall: 'lstat',
  code: 'ENOENT',
  path: '/home/runner/work/<app-name>/<app-name>/clients/website/.open-next/assets'
}
```

This PR adds a if condition to skip asset bundling if the deploy is being made with an `--exclusively` flag to prevent it from trying to copy files that does not exist.