### PR TITLE
fix: connect cf override props with distribution creation

### DIFF
--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -434,7 +434,7 @@ export class NextjsDistribution extends Construct {
 
       distribution = this.props.distribution;
     } else {
-      distribution = this.createCloudFrontDistribution();
+      distribution = this.createCloudFrontDistribution(this.props.cdk?.distribution);
     }
 
     distribution.addBehavior(


### PR DESCRIPTION
Addresses the issue brought up in this discussion post: https://github.com/jetbridge/cdk-nextjs/discussions/163

TLDR: optional custom CloudFront props were not being passed to the create distribution function.