### PR TITLE
fix: 400 Bad request when creating CachePolicy on the Distribution.

### DIFF
--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -250,7 +250,6 @@ export class NextjsDistribution extends Construct {
       queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
       headerBehavior: cloudfront.CacheHeaderBehavior.allowList(
         'accept',
-        'accept-encoding',
         'rsc',
         'next-router-prefetch',
         'next-router-state-tree',


### PR DESCRIPTION
Fixes #189

AllowList accept-encoding headerBehaviour is not compatible with enableAcceptEncodingGzip: true.

My recommendation is to remove accept-encoding from allowList headerBehaviour as default. And the final user can amend as they wish. But like this, the default options will be functional.

Fixes #