### PR TITLE
fix: upload to s3 in chunks

### DIFF
--- a/src/lambdas/nextjs-bucket-deployment.ts
+++ b/src/lambdas/nextjs-bucket-deployment.ts
@@ -259,7 +259,13 @@ function createS3Key({ keyPrefix, path, baseLocalDir }: { keyPrefix?: string; pa
   return join(...objectKeyParts);
 }
 
-function uploadObjects({
+async function* chunkArray(array: string[], chunkSize: number) {
+  for (let i = 0; i < array.length; i += chunkSize) {
+    yield array.slice(i, i + chunkSize);
+  }
+}
+
+async function uploadObjects({
   bucket,
   keyPrefix,
   filePaths,
@@ -272,19 +278,22 @@ function uploadObjects({
   baseLocalDir: string;
   putConfig: CustomResourceProperties['putConfig'];
 }) {
-  const putObjectInputs: PutObjectCommandInput[] = filePaths.map((path) => {
-    const contentType = mime.lookup(path) || undefined;
-    const putObjectOptions = getPutObjectOptions({ path, putConfig });
-    const key = createS3Key({ keyPrefix, path, baseLocalDir });
-    return {
-      ContentType: contentType,
-      ...putObjectOptions,
-      Bucket: bucket,
-      Key: key,
-      Body: createReadStream(path),
-    };
-  });
-  return Promise.all(putObjectInputs.map((input) => s3.send(new PutObjectCommand(input))));
+  for await (const filePathChunk of chunkArray(filePaths, 10)) {
+    const putObjectInputs: PutObjectCommandInput[] = filePathChunk.map((path) => {
+      const contentType = mime.lookup(path) || undefined;
+      const putObjectOptions = getPutObjectOptions({ path, putConfig });
+      const key = createS3Key({ keyPrefix, path, baseLocalDir });
+      return {
+        ContentType: contentType,
+        ...putObjectOptions,
+        Bucket: bucket,
+        Key: key,
+        Body: createReadStream(path),
+      };
+    });
+
+    await Promise.all(putObjectInputs.map((input) => s3.send(new PutObjectCommand(input))));
+  }
 }
 
 /**

--- a/src/lambdas/nextjs-bucket-deployment.ts
+++ b/src/lambdas/nextjs-bucket-deployment.ts
@@ -278,7 +278,7 @@ async function uploadObjects({
   baseLocalDir: string;
   putConfig: CustomResourceProperties['putConfig'];
 }) {
-  for await (const filePathChunk of chunkArray(filePaths, 10)) {
+  for await (const filePathChunk of chunkArray(filePaths, 100)) {
     const putObjectInputs: PutObjectCommandInput[] = filePathChunk.map((path) => {
       const contentType = mime.lookup(path) || undefined;
       const putObjectOptions = getPutObjectOptions({ path, putConfig });


### PR DESCRIPTION
When uploading a site with hundreds of static assets, the custom lambda resource that uploads to S3 will error out with `Error: EMFILE: too many open files`.

This is due to a read stream being opened for every static upload concurrently.

This PR batches the uploads into more manageable chunk sizes so there isn't an limitless number of file pointers opened at once.