### PR TITLE
fix: ignore cookies in image cache policy

### DIFF
--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -348,7 +348,7 @@ export class NextjsDistribution extends Construct {
       new cloudfront.CachePolicy(this, 'ImageCachePolicy', {
         queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
         headerBehavior: cloudfront.CacheHeaderBehavior.allowList('accept'),
-        cookieBehavior: cloudfront.CacheCookieBehavior.all(),
+        cookieBehavior: cloudfront.CacheCookieBehavior.none(),
         defaultTtl: Duration.days(1),
         maxTtl: Duration.days(365),
         minTtl: Duration.days(0),


### PR DESCRIPTION
The value of a cookie would never change how an image is rendered, so cookies should not be included in the image cache policy.