### PR TITLE
fix: re-map authorization header when using secured function urls

### DIFF
--- a/src/lambdas/sign-fn-url.test.ts
+++ b/src/lambdas/sign-fn-url.test.ts
@@ -8,7 +8,13 @@ describe('LambdaOriginRequestIamAuth', () => {
     const event = getFakePageRequest();
     const request = event.Records[0].cf.request;
     await signRequest(request);
-    const securityHeaders = ['x-amz-date', 'x-amz-security-token', 'x-amz-content-sha256', 'authorization'];
+    const securityHeaders = [
+      'x-amz-date',
+      'x-amz-security-token',
+      'x-amz-content-sha256',
+      'authorization',
+      'origin-authorization',
+    ];
     const hasSignedHeaders = securityHeaders.every((h) => h in request.headers);
     expect(hasSignedHeaders).toBe(true);
   });
@@ -35,6 +41,12 @@ function getFakePageRequest(): CloudFrontRequestEvent {
           request: {
             clientIp: '1.1.1.1',
             headers: {
+              authorization: [
+                {
+                  key: 'Authorization',
+                  value: 'Bearer token',
+                },
+              ],
               host: [
                 {
                   key: 'Host',

--- a/src/lambdas/sign-fn-url.ts
+++ b/src/lambdas/sign-fn-url.ts
@@ -109,6 +109,11 @@ export function cfHeadersToHeaderBag(headers: CloudFrontHeaders): Bag {
   // not destructured) is case sensitive. we arbitrarily use case insensitive key
   for (const [headerKey, [{ value }]] of Object.entries(headers)) {
     headerBag[headerKey] = value;
+    // if there is an authorization from CloudFront, move it as
+    // it will be overwritten when the headers are signed
+    if (headerKey === 'authorization') {
+      headerBag['origin-authorization'] = value;
+    }
   }
   return headerBag;
 }


### PR DESCRIPTION
Fixes # https://github.com/jetbridge/cdk-nextjs/issues/214