### PR TITLE
feat: add support for lambda response streaming

### DIFF
--- a/API.md
+++ b/API.md
@@ -2797,6 +2797,7 @@ const nextjsBuildProps: NextjsBuildProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.quiet">quiet</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.skipBuild">skipBuild</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.NextjsBuildProps.property.streaming">streaming</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
@@ -2869,6 +2870,18 @@ public readonly skipBuild: boolean;
 - *Type:* boolean
 
 > [{@link NextjsProps.skipBuild }]({@link NextjsProps.skipBuild })
+
+---
+
+##### `streaming`<sup>Optional</sup> <a name="streaming" id="cdk-nextjs-standalone.NextjsBuildProps.property.streaming"></a>
+
+```typescript
+public readonly streaming: boolean;
+```
+
+- *Type:* boolean
+
+> [{@link NextjsProps.streaming }]({@link NextjsProps.streaming })
 
 ---
 
@@ -3172,6 +3185,7 @@ const nextjsDistributionProps: NextjsDistributionProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.functionUrlAuthType">functionUrlAuthType</a></code> | <code>aws-cdk-lib.aws_lambda.FunctionUrlAuthType</code> | Override lambda function url auth type. |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.nextDomain">nextDomain</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsDomain">NextjsDomain</a></code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.overrides">overrides</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsDistributionOverrides">NextjsDistributionOverrides</a></code> | Override props for every construct. |
+| <code><a href="#cdk-nextjs-standalone.NextjsDistributionProps.property.streaming">streaming</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
@@ -3299,6 +3313,18 @@ public readonly overrides: NextjsDistributionOverrides;
 - *Type:* <a href="#cdk-nextjs-standalone.NextjsDistributionOverrides">NextjsDistributionOverrides</a>
 
 Override props for every construct.
+
+---
+
+##### `streaming`<sup>Optional</sup> <a name="streaming" id="cdk-nextjs-standalone.NextjsDistributionProps.property.streaming"></a>
+
+```typescript
+public readonly streaming: boolean;
+```
+
+- *Type:* boolean
+
+> [{@link NextjsProps.streaming }]({@link NextjsProps.streaming })
 
 ---
 
@@ -3833,6 +3859,7 @@ const nextjsProps: NextjsProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.quiet">quiet</a></code> | <code>boolean</code> | Less build output. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.skipBuild">skipBuild</a></code> | <code>boolean</code> | Skips running Next.js build. Useful if you want to deploy `Nextjs` but haven't made any changes to Next.js app code. |
 | <code><a href="#cdk-nextjs-standalone.NextjsProps.property.skipFullInvalidation">skipFullInvalidation</a></code> | <code>boolean</code> | By default all CloudFront cache will be invalidated on deployment. |
+| <code><a href="#cdk-nextjs-standalone.NextjsProps.property.streaming">streaming</a></code> | <code>boolean</code> | Streaming allows you to send data to the client as it's generated instead of waiting for the entire response to be generated. |
 
 ---
 
@@ -4006,6 +4033,18 @@ By default all CloudFront cache will be invalidated on deployment.
 
 This can be set to true to skip the full cache invalidation, which
 could be important for some users.
+
+---
+
+##### `streaming`<sup>Optional</sup> <a name="streaming" id="cdk-nextjs-standalone.NextjsProps.property.streaming"></a>
+
+```typescript
+public readonly streaming: boolean;
+```
+
+- *Type:* boolean
+
+Streaming allows you to send data to the client as it's generated instead of waiting for the entire response to be generated.
 
 ---
 
@@ -7610,6 +7649,7 @@ const optionalNextjsBuildProps: OptionalNextjsBuildProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.OptionalNextjsBuildProps.property.nextjsPath">nextjsPath</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.OptionalNextjsBuildProps.property.quiet">quiet</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdk-nextjs-standalone.OptionalNextjsBuildProps.property.skipBuild">skipBuild</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#cdk-nextjs-standalone.OptionalNextjsBuildProps.property.streaming">streaming</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
@@ -7673,6 +7713,16 @@ public readonly skipBuild: boolean;
 
 ---
 
+##### `streaming`<sup>Optional</sup> <a name="streaming" id="cdk-nextjs-standalone.OptionalNextjsBuildProps.property.streaming"></a>
+
+```typescript
+public readonly streaming: boolean;
+```
+
+- *Type:* boolean
+
+---
+
 ### OptionalNextjsDistributionProps <a name="OptionalNextjsDistributionProps" id="cdk-nextjs-standalone.OptionalNextjsDistributionProps"></a>
 
 OptionalNextjsDistributionProps.
@@ -7699,6 +7749,7 @@ const optionalNextjsDistributionProps: OptionalNextjsDistributionProps = { ... }
 | <code><a href="#cdk-nextjs-standalone.OptionalNextjsDistributionProps.property.overrides">overrides</a></code> | <code><a href="#cdk-nextjs-standalone.NextjsDistributionOverrides">NextjsDistributionOverrides</a></code> | Override props for every construct. |
 | <code><a href="#cdk-nextjs-standalone.OptionalNextjsDistributionProps.property.serverFunction">serverFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | Lambda function to route all non-static requests to. |
 | <code><a href="#cdk-nextjs-standalone.OptionalNextjsDistributionProps.property.staticAssetsBucket">staticAssetsBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Bucket containing static assets. |
+| <code><a href="#cdk-nextjs-standalone.OptionalNextjsDistributionProps.property.streaming">streaming</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
@@ -7816,6 +7867,16 @@ public readonly staticAssetsBucket: IBucket;
 Bucket containing static assets.
 
 Must be provided if you want to serve static files.
+
+---
+
+##### `streaming`<sup>Optional</sup> <a name="streaming" id="cdk-nextjs-standalone.OptionalNextjsDistributionProps.property.streaming"></a>
+
+```typescript
+public readonly streaming: boolean;
+```
+
+- *Type:* boolean
 
 ---
 

--- a/src/Nextjs.ts
+++ b/src/Nextjs.ts
@@ -100,6 +100,11 @@ export interface NextjsProps {
    * could be important for some users.
    */
   readonly skipFullInvalidation?: boolean;
+  /**
+   * Streaming allows you to send data to the client as it's generated
+   * instead of waiting for the entire response to be generated.
+   */
+  readonly streaming?: boolean;
 }
 
 /**
@@ -160,6 +165,7 @@ export class Nextjs extends Construct {
       environment: props.environment,
       quiet: props.quiet,
       skipBuild: props.skipBuild,
+      streaming: props.streaming,
       ...props.overrides?.nextjs?.nextjsBuildProps,
     });
 
@@ -205,6 +211,7 @@ export class Nextjs extends Construct {
       nextjsPath: props.nextjsPath,
       basePath: props.basePath,
       distribution: props.distribution,
+      streaming: props.streaming,
       staticAssetsBucket: this.staticAssets.bucket,
       nextBuild: this.nextBuild,
       nextDomain: this.domain,

--- a/src/NextjsBuild.ts
+++ b/src/NextjsBuild.ts
@@ -41,6 +41,10 @@ export interface NextjsBuildProps {
    * @see {@link NextjsProps.skipBuild}
    */
   readonly skipBuild?: NextjsProps['skipBuild'];
+  /**
+   * @see {@link NextjsProps.streaming}
+   */
+  readonly streaming?: NextjsProps['streaming'];
 }
 
 /**
@@ -142,7 +146,8 @@ export class NextjsBuild extends Construct {
 
   private build() {
     const buildPath = this.props.buildPath ?? this.props.nextjsPath;
-    const buildCommand = this.props.buildCommand ?? 'npx open-next@^2 build';
+    const defaultBuildCommand = `npx open-next@^2 build ${this.props.streaming ? '--streaming' : ''}`;
+    const buildCommand = this.props.buildCommand ?? defaultBuildCommand;
     // run build
     if (!this.props.quiet) {
       console.debug(`Running "${buildCommand}" in`, buildPath);

--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -13,7 +13,7 @@ import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import { HttpOriginProps } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Runtime, InvokeMode } from 'aws-cdk-lib/aws-lambda';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { NEXTJS_BUILD_DIR, NEXTJS_STATIC_DIR } from './constants';
@@ -89,6 +89,10 @@ export interface NextjsDistributionProps {
    * Must be provided if you want to serve static files.
    */
   readonly staticAssetsBucket: s3.IBucket;
+  /**
+   * @see {@link NextjsProps.streaming}
+   */
+  readonly streaming?: boolean;
 }
 
 /**
@@ -256,7 +260,10 @@ export class NextjsDistribution extends Construct {
   }
 
   private createServerBehaviorOptions(): cloudfront.BehaviorOptions {
-    const fnUrl = this.props.serverFunction.addFunctionUrl({ authType: this.fnUrlAuthType });
+    const fnUrl = this.props.serverFunction.addFunctionUrl({
+      authType: this.fnUrlAuthType,
+      invokeMode: this.props.streaming ? InvokeMode.RESPONSE_STREAM : InvokeMode.BUFFERED,
+    });
     const origin = new origins.HttpOrigin(Fn.parseDomainName(fnUrl.url), this.props.overrides?.serverHttpOriginProps);
     const serverBehaviorOptions = this.props.overrides?.serverBehaviorOptions;
 

--- a/src/generated-structs/OptionalNextjsBuildProps.ts
+++ b/src/generated-structs/OptionalNextjsBuildProps.ts
@@ -7,6 +7,10 @@ export interface OptionalNextjsBuildProps {
   /**
    * @stability stable
    */
+  readonly streaming?: boolean;
+  /**
+   * @stability stable
+   */
   readonly skipBuild?: boolean;
   /**
    * @stability stable

--- a/src/generated-structs/OptionalNextjsDistributionProps.ts
+++ b/src/generated-structs/OptionalNextjsDistributionProps.ts
@@ -7,6 +7,10 @@ import type { aws_cloudfront, aws_lambda, aws_s3 } from 'aws-cdk-lib';
  */
 export interface OptionalNextjsDistributionProps {
   /**
+   * @stability stable
+   */
+  readonly streaming?: boolean;
+  /**
    * Override props for every construct.
    * @stability stable
    */


### PR DESCRIPTION
Adds an optional parameter `streaming: true` to allow deploying Next with Lambda response streaming.

Most of the work is [already handed](https://open-next.js.org/v2/inner_workings/streaming) by `open-next` by passing the `--streaming` argument. We just need to also set the Lambda function URL invoke mode to `RESPONSE_STREAM`.